### PR TITLE
refactored dashboard Rmd to preprocess input data into small 218kb cs…

### DIFF
--- a/docs/output_transport_modes.csv
+++ b/docs/output_transport_modes.csv
@@ -1,0 +1,2101 @@
+age,sex,scenario,scen,prop,mode,max_walk,max_cycle,purpose,title1
+65plus,males,Base case,all_0_2,0.009363888445903697,Cycling,0,2,all,2km ≥ cycling
+65plus,males,Base case,all_0_2,0.6187454191111116,Car,0,2,all,2km ≥ cycling
+65plus,males,Base case,all_0_2,0.0039148015929756025,Other,0,2,all,2km ≥ cycling
+65plus,males,Base case,all_0_2,0.07127689436478812,Public transport,0,2,all,2km ≥ cycling
+65plus,males,Base case,all_0_2,0.296698996485221,Walking,0,2,all,2km ≥ cycling
+65plus,males,Base case,commuting_0_2,0.009363888445903697,Cycling,0,2,commuting,2km ≥ cycling
+65plus,males,Base case,commuting_0_2,0.6187454191111116,Car,0,2,commuting,2km ≥ cycling
+65plus,males,Base case,commuting_0_2,0.0039148015929756025,Other,0,2,commuting,2km ≥ cycling
+65plus,males,Base case,commuting_0_2,0.07127689436478812,Public transport,0,2,commuting,2km ≥ cycling
+65plus,males,Base case,commuting_0_2,0.296698996485221,Walking,0,2,commuting,2km ≥ cycling
+65plus,males,Base case,all_0_5,0.009363888445903697,Cycling,0,5,all,5km ≥ cycling
+65plus,males,Base case,all_0_5,0.6187454191111116,Car,0,5,all,5km ≥ cycling
+65plus,males,Base case,all_0_5,0.0039148015929756025,Other,0,5,all,5km ≥ cycling
+65plus,males,Base case,all_0_5,0.07127689436478812,Public transport,0,5,all,5km ≥ cycling
+65plus,males,Base case,all_0_5,0.296698996485221,Walking,0,5,all,5km ≥ cycling
+65plus,males,Base case,commuting_0_5,0.009363888445903697,Cycling,0,5,commuting,5km ≥ cycling
+65plus,males,Base case,commuting_0_5,0.6187454191111116,Car,0,5,commuting,5km ≥ cycling
+65plus,males,Base case,commuting_0_5,0.0039148015929756025,Other,0,5,commuting,5km ≥ cycling
+65plus,males,Base case,commuting_0_5,0.07127689436478812,Public transport,0,5,commuting,5km ≥ cycling
+65plus,males,Base case,commuting_0_5,0.296698996485221,Walking,0,5,commuting,5km ≥ cycling
+65plus,males,Base case,all_1_0,0.009363888445903697,Cycling,1,0,all,1km ≥ walking
+65plus,males,Base case,all_1_0,0.6187454191111116,Car,1,0,all,1km ≥ walking
+65plus,males,Base case,all_1_0,0.0039148015929756025,Other,1,0,all,1km ≥ walking
+65plus,males,Base case,all_1_0,0.07127689436478812,Public transport,1,0,all,1km ≥ walking
+65plus,males,Base case,all_1_0,0.296698996485221,Walking,1,0,all,1km ≥ walking
+65plus,males,Base case,commuting_1_0,0.009363888445903697,Cycling,1,0,commuting,1km ≥ walking
+65plus,males,Base case,commuting_1_0,0.6187454191111116,Car,1,0,commuting,1km ≥ walking
+65plus,males,Base case,commuting_1_0,0.0039148015929756025,Other,1,0,commuting,1km ≥ walking
+65plus,males,Base case,commuting_1_0,0.07127689436478812,Public transport,1,0,commuting,1km ≥ walking
+65plus,males,Base case,commuting_1_0,0.296698996485221,Walking,1,0,commuting,1km ≥ walking
+65plus,males,Base case,all_1_2,0.009363888445903697,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Base case,all_1_2,0.6187454191111116,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Base case,all_1_2,0.0039148015929756025,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Base case,all_1_2,0.07127689436478812,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Base case,all_1_2,0.296698996485221,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Base case,commuting_1_2,0.009363888445903697,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Base case,commuting_1_2,0.6187454191111116,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Base case,commuting_1_2,0.0039148015929756025,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Base case,commuting_1_2,0.07127689436478812,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Base case,commuting_1_2,0.296698996485221,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Base case,all_1_5,0.009363888445903697,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Base case,all_1_5,0.6187454191111116,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Base case,all_1_5,0.0039148015929756025,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Base case,all_1_5,0.07127689436478812,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Base case,all_1_5,0.296698996485221,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Base case,commuting_1_5,0.009363888445903697,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Base case,commuting_1_5,0.6187454191111116,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Base case,commuting_1_5,0.0039148015929756025,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Base case,commuting_1_5,0.07127689436478812,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Base case,commuting_1_5,0.296698996485221,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Base case,all_2_0,0.009363888445903697,Cycling,2,0,all,2km ≥ walking
+65plus,males,Base case,all_2_0,0.6187454191111116,Car,2,0,all,2km ≥ walking
+65plus,males,Base case,all_2_0,0.0039148015929756025,Other,2,0,all,2km ≥ walking
+65plus,males,Base case,all_2_0,0.07127689436478812,Public transport,2,0,all,2km ≥ walking
+65plus,males,Base case,all_2_0,0.296698996485221,Walking,2,0,all,2km ≥ walking
+65plus,males,Base case,commuting_2_0,0.009363888445903697,Cycling,2,0,commuting,2km ≥ walking
+65plus,males,Base case,commuting_2_0,0.6187454191111116,Car,2,0,commuting,2km ≥ walking
+65plus,males,Base case,commuting_2_0,0.0039148015929756025,Other,2,0,commuting,2km ≥ walking
+65plus,males,Base case,commuting_2_0,0.07127689436478812,Public transport,2,0,commuting,2km ≥ walking
+65plus,males,Base case,commuting_2_0,0.296698996485221,Walking,2,0,commuting,2km ≥ walking
+65plus,males,Base case,all_2_5,0.009363888445903697,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,males,Base case,all_2_5,0.6187454191111116,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,males,Base case,all_2_5,0.0039148015929756025,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,males,Base case,all_2_5,0.07127689436478812,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,males,Base case,all_2_5,0.296698996485221,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,males,Base case,commuting_2_5,0.009363888445903697,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,males,Base case,commuting_2_5,0.6187454191111116,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,males,Base case,commuting_2_5,0.0039148015929756025,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,males,Base case,commuting_2_5,0.07127689436478812,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,males,Base case,commuting_2_5,0.296698996485221,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,males,Scenario,all_0_2,0.15938477894054923,Cycling,0,2,all,2km ≥ cycling
+65plus,males,Scenario,all_0_2,0.468724528616466,Car,0,2,all,2km ≥ cycling
+65plus,males,Scenario,all_0_2,0.0039148015929756025,Other,0,2,all,2km ≥ cycling
+65plus,males,Scenario,all_0_2,0.07127689436478812,Public transport,0,2,all,2km ≥ cycling
+65plus,males,Scenario,all_0_2,0.296698996485221,Walking,0,2,all,2km ≥ cycling
+65plus,males,Scenario,commuting_0_2,0.011672874015240099,Cycling,0,2,commuting,2km ≥ cycling
+65plus,males,Scenario,commuting_0_2,0.6164364335417751,Car,0,2,commuting,2km ≥ cycling
+65plus,males,Scenario,commuting_0_2,0.0039148015929756025,Other,0,2,commuting,2km ≥ cycling
+65plus,males,Scenario,commuting_0_2,0.07127689436478812,Public transport,0,2,commuting,2km ≥ cycling
+65plus,males,Scenario,commuting_0_2,0.296698996485221,Walking,0,2,commuting,2km ≥ cycling
+65plus,males,Scenario,all_0_5,0.3662504115690819,Cycling,0,5,all,5km ≥ cycling
+65plus,males,Scenario,all_0_5,0.2618588959879334,Car,0,5,all,5km ≥ cycling
+65plus,males,Scenario,all_0_5,0.0039148015929756025,Other,0,5,all,5km ≥ cycling
+65plus,males,Scenario,all_0_5,0.07127689436478812,Public transport,0,5,all,5km ≥ cycling
+65plus,males,Scenario,all_0_5,0.296698996485221,Walking,0,5,all,5km ≥ cycling
+65plus,males,Scenario,commuting_0_5,0.018968782890696336,Cycling,0,5,commuting,5km ≥ cycling
+65plus,males,Scenario,commuting_0_5,0.609140524666319,Car,0,5,commuting,5km ≥ cycling
+65plus,males,Scenario,commuting_0_5,0.0039148015929756025,Other,0,5,commuting,5km ≥ cycling
+65plus,males,Scenario,commuting_0_5,0.07127689436478812,Public transport,0,5,commuting,5km ≥ cycling
+65plus,males,Scenario,commuting_0_5,0.296698996485221,Walking,0,5,commuting,5km ≥ cycling
+65plus,males,Scenario,all_1_0,0.009363888445903697,Cycling,1,0,all,1km ≥ walking
+65plus,males,Scenario,all_1_0,0.5746694526766744,Car,1,0,all,1km ≥ walking
+65plus,males,Scenario,all_1_0,0.0039148015929756025,Other,1,0,all,1km ≥ walking
+65plus,males,Scenario,all_1_0,0.07127689436478812,Public transport,1,0,all,1km ≥ walking
+65plus,males,Scenario,all_1_0,0.3407749629196583,Walking,1,0,all,1km ≥ walking
+65plus,males,Scenario,commuting_1_0,0.009363888445903697,Cycling,1,0,commuting,1km ≥ walking
+65plus,males,Scenario,commuting_1_0,0.6174721409814097,Car,1,0,commuting,1km ≥ walking
+65plus,males,Scenario,commuting_1_0,0.0039148015929756025,Other,1,0,commuting,1km ≥ walking
+65plus,males,Scenario,commuting_1_0,0.07127689436478812,Public transport,1,0,commuting,1km ≥ walking
+65plus,males,Scenario,commuting_1_0,0.29797227461492287,Walking,1,0,commuting,1km ≥ walking
+65plus,males,Scenario,all_1_2,0.115308812506112,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Scenario,all_1_2,0.468724528616466,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Scenario,all_1_2,0.0039148015929756025,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Scenario,all_1_2,0.07127689436478812,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Scenario,all_1_2,0.3407749629196583,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Scenario,commuting_1_2,0.010399595885538258,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Scenario,commuting_1_2,0.6164364335417751,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Scenario,commuting_1_2,0.0039148015929756025,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Scenario,commuting_1_2,0.07127689436478812,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Scenario,commuting_1_2,0.29797227461492287,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,males,Scenario,all_1_5,0.32217444513464466,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Scenario,all_1_5,0.2618588959879334,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Scenario,all_1_5,0.0039148015929756025,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Scenario,all_1_5,0.07127689436478812,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Scenario,all_1_5,0.3407749629196583,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Scenario,commuting_1_5,0.017695504760994497,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Scenario,commuting_1_5,0.609140524666319,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Scenario,commuting_1_5,0.0039148015929756025,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Scenario,commuting_1_5,0.07127689436478812,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Scenario,commuting_1_5,0.29797227461492287,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,males,Scenario,all_2_0,0.009363888445903697,Cycling,2,0,all,2km ≥ walking
+65plus,males,Scenario,all_2_0,0.468724528616466,Car,2,0,all,2km ≥ walking
+65plus,males,Scenario,all_2_0,0.0039148015929756025,Other,2,0,all,2km ≥ walking
+65plus,males,Scenario,all_2_0,0.07127689436478812,Public transport,2,0,all,2km ≥ walking
+65plus,males,Scenario,all_2_0,0.4467198869798666,Walking,2,0,all,2km ≥ walking
+65plus,males,Scenario,commuting_2_0,0.009363888445903697,Cycling,2,0,commuting,2km ≥ walking
+65plus,males,Scenario,commuting_2_0,0.6164364335417751,Car,2,0,commuting,2km ≥ walking
+65plus,males,Scenario,commuting_2_0,0.0039148015929756025,Other,2,0,commuting,2km ≥ walking
+65plus,males,Scenario,commuting_2_0,0.07127689436478812,Public transport,2,0,commuting,2km ≥ walking
+65plus,males,Scenario,commuting_2_0,0.2990079820545574,Walking,2,0,commuting,2km ≥ walking
+65plus,males,Scenario,all_2_5,0.21622952107443635,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,males,Scenario,all_2_5,0.2618588959879334,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,males,Scenario,all_2_5,0.0039148015929756025,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,males,Scenario,all_2_5,0.07127689436478812,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,males,Scenario,all_2_5,0.4467198869798666,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,males,Scenario,commuting_2_5,0.016659797321359932,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,males,Scenario,commuting_2_5,0.609140524666319,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,males,Scenario,commuting_2_5,0.0039148015929756025,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,males,Scenario,commuting_2_5,0.07127689436478812,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,males,Scenario,commuting_2_5,0.2990079820545574,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Base case,all_0_2,0.0038677487295926856,Cycling,0,2,all,2km ≥ cycling
+65plus,females,Base case,all_0_2,0.6676885183097748,Car,0,2,all,2km ≥ cycling
+65plus,females,Base case,all_0_2,9.430862178785228e-4,Other,0,2,all,2km ≥ cycling
+65plus,females,Base case,all_0_2,0.05208856027220781,Public transport,0,2,all,2km ≥ cycling
+65plus,females,Base case,all_0_2,0.2754120864705461,Walking,0,2,all,2km ≥ cycling
+65plus,females,Base case,commuting_0_2,0.0038677487295926856,Cycling,0,2,commuting,2km ≥ cycling
+65plus,females,Base case,commuting_0_2,0.6676885183097748,Car,0,2,commuting,2km ≥ cycling
+65plus,females,Base case,commuting_0_2,9.430862178785228e-4,Other,0,2,commuting,2km ≥ cycling
+65plus,females,Base case,commuting_0_2,0.05208856027220781,Public transport,0,2,commuting,2km ≥ cycling
+65plus,females,Base case,commuting_0_2,0.2754120864705461,Walking,0,2,commuting,2km ≥ cycling
+65plus,females,Base case,all_0_5,0.0038677487295926856,Cycling,0,5,all,5km ≥ cycling
+65plus,females,Base case,all_0_5,0.6676885183097748,Car,0,5,all,5km ≥ cycling
+65plus,females,Base case,all_0_5,9.430862178785228e-4,Other,0,5,all,5km ≥ cycling
+65plus,females,Base case,all_0_5,0.05208856027220781,Public transport,0,5,all,5km ≥ cycling
+65plus,females,Base case,all_0_5,0.2754120864705461,Walking,0,5,all,5km ≥ cycling
+65plus,females,Base case,commuting_0_5,0.0038677487295926856,Cycling,0,5,commuting,5km ≥ cycling
+65plus,females,Base case,commuting_0_5,0.6676885183097748,Car,0,5,commuting,5km ≥ cycling
+65plus,females,Base case,commuting_0_5,9.430862178785228e-4,Other,0,5,commuting,5km ≥ cycling
+65plus,females,Base case,commuting_0_5,0.05208856027220781,Public transport,0,5,commuting,5km ≥ cycling
+65plus,females,Base case,commuting_0_5,0.2754120864705461,Walking,0,5,commuting,5km ≥ cycling
+65plus,females,Base case,all_1_0,0.0038677487295926856,Cycling,1,0,all,1km ≥ walking
+65plus,females,Base case,all_1_0,0.6676885183097748,Car,1,0,all,1km ≥ walking
+65plus,females,Base case,all_1_0,9.430862178785228e-4,Other,1,0,all,1km ≥ walking
+65plus,females,Base case,all_1_0,0.05208856027220781,Public transport,1,0,all,1km ≥ walking
+65plus,females,Base case,all_1_0,0.2754120864705461,Walking,1,0,all,1km ≥ walking
+65plus,females,Base case,commuting_1_0,0.0038677487295926856,Cycling,1,0,commuting,1km ≥ walking
+65plus,females,Base case,commuting_1_0,0.6676885183097748,Car,1,0,commuting,1km ≥ walking
+65plus,females,Base case,commuting_1_0,9.430862178785228e-4,Other,1,0,commuting,1km ≥ walking
+65plus,females,Base case,commuting_1_0,0.05208856027220781,Public transport,1,0,commuting,1km ≥ walking
+65plus,females,Base case,commuting_1_0,0.2754120864705461,Walking,1,0,commuting,1km ≥ walking
+65plus,females,Base case,all_1_2,0.0038677487295926856,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Base case,all_1_2,0.6676885183097748,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Base case,all_1_2,9.430862178785228e-4,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Base case,all_1_2,0.05208856027220781,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Base case,all_1_2,0.2754120864705461,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Base case,commuting_1_2,0.0038677487295926856,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Base case,commuting_1_2,0.6676885183097748,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Base case,commuting_1_2,9.430862178785228e-4,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Base case,commuting_1_2,0.05208856027220781,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Base case,commuting_1_2,0.2754120864705461,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Base case,all_1_5,0.0038677487295926856,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Base case,all_1_5,0.6676885183097748,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Base case,all_1_5,9.430862178785228e-4,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Base case,all_1_5,0.05208856027220781,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Base case,all_1_5,0.2754120864705461,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Base case,commuting_1_5,0.0038677487295926856,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Base case,commuting_1_5,0.6676885183097748,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Base case,commuting_1_5,9.430862178785228e-4,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Base case,commuting_1_5,0.05208856027220781,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Base case,commuting_1_5,0.2754120864705461,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Base case,all_2_0,0.0038677487295926856,Cycling,2,0,all,2km ≥ walking
+65plus,females,Base case,all_2_0,0.6676885183097748,Car,2,0,all,2km ≥ walking
+65plus,females,Base case,all_2_0,9.430862178785228e-4,Other,2,0,all,2km ≥ walking
+65plus,females,Base case,all_2_0,0.05208856027220781,Public transport,2,0,all,2km ≥ walking
+65plus,females,Base case,all_2_0,0.2754120864705461,Walking,2,0,all,2km ≥ walking
+65plus,females,Base case,commuting_2_0,0.0038677487295926856,Cycling,2,0,commuting,2km ≥ walking
+65plus,females,Base case,commuting_2_0,0.6676885183097748,Car,2,0,commuting,2km ≥ walking
+65plus,females,Base case,commuting_2_0,9.430862178785228e-4,Other,2,0,commuting,2km ≥ walking
+65plus,females,Base case,commuting_2_0,0.05208856027220781,Public transport,2,0,commuting,2km ≥ walking
+65plus,females,Base case,commuting_2_0,0.2754120864705461,Walking,2,0,commuting,2km ≥ walking
+65plus,females,Base case,all_2_5,0.0038677487295926856,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Base case,all_2_5,0.6676885183097748,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Base case,all_2_5,9.430862178785228e-4,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Base case,all_2_5,0.05208856027220781,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Base case,all_2_5,0.2754120864705461,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Base case,commuting_2_5,0.0038677487295926856,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Base case,commuting_2_5,0.6676885183097748,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Base case,commuting_2_5,9.430862178785228e-4,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Base case,commuting_2_5,0.05208856027220781,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Base case,commuting_2_5,0.2754120864705461,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Scenario,all_0_2,0.189728011614542,Cycling,0,2,all,2km ≥ cycling
+65plus,females,Scenario,all_0_2,0.48182825542482555,Car,0,2,all,2km ≥ cycling
+65plus,females,Scenario,all_0_2,9.430862178785228e-4,Other,0,2,all,2km ≥ cycling
+65plus,females,Scenario,all_0_2,0.05208856027220781,Public transport,0,2,all,2km ≥ cycling
+65plus,females,Scenario,all_0_2,0.2754120864705461,Walking,0,2,all,2km ≥ cycling
+65plus,females,Scenario,commuting_0_2,0.017842963799463988,Cycling,0,2,commuting,2km ≥ cycling
+65plus,females,Scenario,commuting_0_2,0.6537133032399035,Car,0,2,commuting,2km ≥ cycling
+65plus,females,Scenario,commuting_0_2,9.430862178785228e-4,Other,0,2,commuting,2km ≥ cycling
+65plus,females,Scenario,commuting_0_2,0.05208856027220781,Public transport,0,2,commuting,2km ≥ cycling
+65plus,females,Scenario,commuting_0_2,0.2754120864705461,Walking,0,2,commuting,2km ≥ cycling
+65plus,females,Scenario,all_0_5,0.3794282416256115,Cycling,0,5,all,5km ≥ cycling
+65plus,females,Scenario,all_0_5,0.29212802541375604,Car,0,5,all,5km ≥ cycling
+65plus,females,Scenario,all_0_5,9.430862178785228e-4,Other,0,5,all,5km ≥ cycling
+65plus,females,Scenario,all_0_5,0.05208856027220781,Public transport,0,5,all,5km ≥ cycling
+65plus,females,Scenario,all_0_5,0.2754120864705461,Walking,0,5,all,5km ≥ cycling
+65plus,females,Scenario,commuting_0_5,0.027511572392581073,Cycling,0,5,commuting,5km ≥ cycling
+65plus,females,Scenario,commuting_0_5,0.6440446946467865,Car,0,5,commuting,5km ≥ cycling
+65plus,females,Scenario,commuting_0_5,9.430862178785228e-4,Other,0,5,commuting,5km ≥ cycling
+65plus,females,Scenario,commuting_0_5,0.05208856027220781,Public transport,0,5,commuting,5km ≥ cycling
+65plus,females,Scenario,commuting_0_5,0.2754120864705461,Walking,0,5,commuting,5km ≥ cycling
+65plus,females,Scenario,all_1_0,0.0038677487295926856,Cycling,1,0,all,1km ≥ walking
+65plus,females,Scenario,all_1_0,0.613471726933093,Car,1,0,all,1km ≥ walking
+65plus,females,Scenario,all_1_0,9.430862178785228e-4,Other,1,0,all,1km ≥ walking
+65plus,females,Scenario,all_1_0,0.05208856027220781,Public transport,1,0,all,1km ≥ walking
+65plus,females,Scenario,all_1_0,0.32962887784722794,Walking,1,0,all,1km ≥ walking
+65plus,females,Scenario,commuting_1_0,0.0038677487295926856,Cycling,1,0,commuting,1km ≥ walking
+65plus,females,Scenario,commuting_1_0,0.6638261503577778,Car,1,0,commuting,1km ≥ walking
+65plus,females,Scenario,commuting_1_0,9.430862178785228e-4,Other,1,0,commuting,1km ≥ walking
+65plus,females,Scenario,commuting_1_0,0.05208856027220781,Public transport,1,0,commuting,1km ≥ walking
+65plus,females,Scenario,commuting_1_0,0.2792744544225432,Walking,1,0,commuting,1km ≥ walking
+65plus,females,Scenario,all_1_2,0.13551122023786014,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Scenario,all_1_2,0.48182825542482555,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Scenario,all_1_2,9.430862178785228e-4,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Scenario,all_1_2,0.05208856027220781,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Scenario,all_1_2,0.32962887784722794,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Scenario,commuting_1_2,0.013980595847466937,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Scenario,commuting_1_2,0.6537133032399035,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Scenario,commuting_1_2,9.430862178785228e-4,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Scenario,commuting_1_2,0.05208856027220781,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Scenario,commuting_1_2,0.2792744544225432,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females,Scenario,all_1_5,0.32521145024892967,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Scenario,all_1_5,0.29212802541375604,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Scenario,all_1_5,9.430862178785228e-4,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Scenario,all_1_5,0.05208856027220781,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Scenario,all_1_5,0.32962887784722794,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Scenario,commuting_1_5,0.02364920444058402,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Scenario,commuting_1_5,0.6440446946467865,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Scenario,commuting_1_5,9.430862178785228e-4,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Scenario,commuting_1_5,0.05208856027220781,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Scenario,commuting_1_5,0.2792744544225432,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females,Scenario,all_2_0,0.0038677487295926856,Cycling,2,0,all,2km ≥ walking
+65plus,females,Scenario,all_2_0,0.48182825542482555,Car,2,0,all,2km ≥ walking
+65plus,females,Scenario,all_2_0,9.430862178785228e-4,Other,2,0,all,2km ≥ walking
+65plus,females,Scenario,all_2_0,0.05208856027220781,Public transport,2,0,all,2km ≥ walking
+65plus,females,Scenario,all_2_0,0.46127234935549544,Walking,2,0,all,2km ≥ walking
+65plus,females,Scenario,commuting_2_0,0.0038677487295926856,Cycling,2,0,commuting,2km ≥ walking
+65plus,females,Scenario,commuting_2_0,0.6537133032399035,Car,2,0,commuting,2km ≥ walking
+65plus,females,Scenario,commuting_2_0,9.430862178785228e-4,Other,2,0,commuting,2km ≥ walking
+65plus,females,Scenario,commuting_2_0,0.05208856027220781,Public transport,2,0,commuting,2km ≥ walking
+65plus,females,Scenario,commuting_2_0,0.2893873015404174,Walking,2,0,commuting,2km ≥ walking
+65plus,females,Scenario,all_2_5,0.1935679787406622,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Scenario,all_2_5,0.29212802541375604,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Scenario,all_2_5,9.430862178785228e-4,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Scenario,all_2_5,0.05208856027220781,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Scenario,all_2_5,0.46127234935549544,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Scenario,commuting_2_5,0.013536357322709771,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Scenario,commuting_2_5,0.6440446946467865,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Scenario,commuting_2_5,9.430862178785228e-4,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Scenario,commuting_2_5,0.05208856027220781,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females,Scenario,commuting_2_5,0.2893873015404174,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Base case,all_0_2,0.006615510600756916,Cycling,0,2,all,2km ≥ cycling
+65plus,females and males,Base case,all_0_2,0.643219711333201,Car,0,2,all,2km ≥ cycling
+65plus,females and males,Base case,all_0_2,0.002428777379515324,Other,0,2,all,2km ≥ cycling
+65plus,females and males,Base case,all_0_2,0.06168165206248378,Public transport,0,2,all,2km ≥ cycling
+65plus,females and males,Base case,all_0_2,0.286054348624043,Walking,0,2,all,2km ≥ cycling
+65plus,females and males,Base case,commuting_0_2,0.006615510600756916,Cycling,0,2,commuting,2km ≥ cycling
+65plus,females and males,Base case,commuting_0_2,0.643219711333201,Car,0,2,commuting,2km ≥ cycling
+65plus,females and males,Base case,commuting_0_2,0.002428777379515324,Other,0,2,commuting,2km ≥ cycling
+65plus,females and males,Base case,commuting_0_2,0.06168165206248378,Public transport,0,2,commuting,2km ≥ cycling
+65plus,females and males,Base case,commuting_0_2,0.286054348624043,Walking,0,2,commuting,2km ≥ cycling
+65plus,females and males,Base case,all_0_5,0.006615510600756916,Cycling,0,5,all,5km ≥ cycling
+65plus,females and males,Base case,all_0_5,0.643219711333201,Car,0,5,all,5km ≥ cycling
+65plus,females and males,Base case,all_0_5,0.002428777379515324,Other,0,5,all,5km ≥ cycling
+65plus,females and males,Base case,all_0_5,0.06168165206248378,Public transport,0,5,all,5km ≥ cycling
+65plus,females and males,Base case,all_0_5,0.286054348624043,Walking,0,5,all,5km ≥ cycling
+65plus,females and males,Base case,commuting_0_5,0.006615510600756916,Cycling,0,5,commuting,5km ≥ cycling
+65plus,females and males,Base case,commuting_0_5,0.643219711333201,Car,0,5,commuting,5km ≥ cycling
+65plus,females and males,Base case,commuting_0_5,0.002428777379515324,Other,0,5,commuting,5km ≥ cycling
+65plus,females and males,Base case,commuting_0_5,0.06168165206248378,Public transport,0,5,commuting,5km ≥ cycling
+65plus,females and males,Base case,commuting_0_5,0.286054348624043,Walking,0,5,commuting,5km ≥ cycling
+65plus,females and males,Base case,all_1_0,0.006615510600756916,Cycling,1,0,all,1km ≥ walking
+65plus,females and males,Base case,all_1_0,0.643219711333201,Car,1,0,all,1km ≥ walking
+65plus,females and males,Base case,all_1_0,0.002428777379515324,Other,1,0,all,1km ≥ walking
+65plus,females and males,Base case,all_1_0,0.06168165206248378,Public transport,1,0,all,1km ≥ walking
+65plus,females and males,Base case,all_1_0,0.286054348624043,Walking,1,0,all,1km ≥ walking
+65plus,females and males,Base case,commuting_1_0,0.006615510600756916,Cycling,1,0,commuting,1km ≥ walking
+65plus,females and males,Base case,commuting_1_0,0.643219711333201,Car,1,0,commuting,1km ≥ walking
+65plus,females and males,Base case,commuting_1_0,0.002428777379515324,Other,1,0,commuting,1km ≥ walking
+65plus,females and males,Base case,commuting_1_0,0.06168165206248378,Public transport,1,0,commuting,1km ≥ walking
+65plus,females and males,Base case,commuting_1_0,0.286054348624043,Walking,1,0,commuting,1km ≥ walking
+65plus,females and males,Base case,all_1_2,0.006615510600756916,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Base case,all_1_2,0.643219711333201,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Base case,all_1_2,0.002428777379515324,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Base case,all_1_2,0.06168165206248378,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Base case,all_1_2,0.286054348624043,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Base case,commuting_1_2,0.006615510600756916,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Base case,commuting_1_2,0.643219711333201,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Base case,commuting_1_2,0.002428777379515324,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Base case,commuting_1_2,0.06168165206248378,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Base case,commuting_1_2,0.286054348624043,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Base case,all_1_5,0.006615510600756916,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Base case,all_1_5,0.643219711333201,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Base case,all_1_5,0.002428777379515324,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Base case,all_1_5,0.06168165206248378,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Base case,all_1_5,0.286054348624043,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Base case,commuting_1_5,0.006615510600756916,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Base case,commuting_1_5,0.643219711333201,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Base case,commuting_1_5,0.002428777379515324,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Base case,commuting_1_5,0.06168165206248378,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Base case,commuting_1_5,0.286054348624043,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Base case,all_2_0,0.006615510600756916,Cycling,2,0,all,2km ≥ walking
+65plus,females and males,Base case,all_2_0,0.643219711333201,Car,2,0,all,2km ≥ walking
+65plus,females and males,Base case,all_2_0,0.002428777379515324,Other,2,0,all,2km ≥ walking
+65plus,females and males,Base case,all_2_0,0.06168165206248378,Public transport,2,0,all,2km ≥ walking
+65plus,females and males,Base case,all_2_0,0.286054348624043,Walking,2,0,all,2km ≥ walking
+65plus,females and males,Base case,commuting_2_0,0.006615510600756916,Cycling,2,0,commuting,2km ≥ walking
+65plus,females and males,Base case,commuting_2_0,0.643219711333201,Car,2,0,commuting,2km ≥ walking
+65plus,females and males,Base case,commuting_2_0,0.002428777379515324,Other,2,0,commuting,2km ≥ walking
+65plus,females and males,Base case,commuting_2_0,0.06168165206248378,Public transport,2,0,commuting,2km ≥ walking
+65plus,females and males,Base case,commuting_2_0,0.286054348624043,Walking,2,0,commuting,2km ≥ walking
+65plus,females and males,Base case,all_2_5,0.006615510600756916,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Base case,all_2_5,0.643219711333201,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Base case,all_2_5,0.002428777379515324,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Base case,all_2_5,0.06168165206248378,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Base case,all_2_5,0.286054348624043,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Base case,commuting_2_5,0.006615510600756916,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Base case,commuting_2_5,0.643219711333201,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Base case,commuting_2_5,0.002428777379515324,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Base case,commuting_2_5,0.06168165206248378,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Base case,commuting_2_5,0.286054348624043,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Scenario,all_0_2,0.17455809562022595,Cycling,0,2,all,2km ≥ cycling
+65plus,females and males,Scenario,all_0_2,0.4752771263137319,Car,0,2,all,2km ≥ cycling
+65plus,females and males,Scenario,all_0_2,0.002428777379515324,Other,0,2,all,2km ≥ cycling
+65plus,females and males,Scenario,all_0_2,0.06168165206248378,Public transport,0,2,all,2km ≥ cycling
+65plus,females and males,Scenario,all_0_2,0.286054348624043,Walking,0,2,all,2km ≥ cycling
+65plus,females and males,Scenario,commuting_0_2,0.014758264660459975,Cycling,0,2,commuting,2km ≥ cycling
+65plus,females and males,Scenario,commuting_0_2,0.6350769572734979,Car,0,2,commuting,2km ≥ cycling
+65plus,females and males,Scenario,commuting_0_2,0.002428777379515324,Other,0,2,commuting,2km ≥ cycling
+65plus,females and males,Scenario,commuting_0_2,0.06168165206248378,Public transport,0,2,commuting,2km ≥ cycling
+65plus,females and males,Scenario,commuting_0_2,0.286054348624043,Walking,0,2,commuting,2km ≥ cycling
+65plus,females and males,Scenario,all_0_5,0.37284006504295397,Cycling,0,5,all,5km ≥ cycling
+65plus,females and males,Scenario,all_0_5,0.2769951568910039,Car,0,5,all,5km ≥ cycling
+65plus,females and males,Scenario,all_0_5,0.002428777379515324,Other,0,5,all,5km ≥ cycling
+65plus,females and males,Scenario,all_0_5,0.06168165206248378,Public transport,0,5,all,5km ≥ cycling
+65plus,females and males,Scenario,all_0_5,0.286054348624043,Walking,0,5,all,5km ≥ cycling
+65plus,females and males,Scenario,commuting_0_5,0.023240656353638686,Cycling,0,5,commuting,5km ≥ cycling
+65plus,females and males,Scenario,commuting_0_5,0.6265945655803192,Car,0,5,commuting,5km ≥ cycling
+65plus,females and males,Scenario,commuting_0_5,0.002428777379515324,Other,0,5,commuting,5km ≥ cycling
+65plus,females and males,Scenario,commuting_0_5,0.06168165206248378,Public transport,0,5,commuting,5km ≥ cycling
+65plus,females and males,Scenario,commuting_0_5,0.286054348624043,Walking,0,5,commuting,5km ≥ cycling
+65plus,females and males,Scenario,all_1_0,0.006615510600756916,Cycling,1,0,all,1km ≥ walking
+65plus,females and males,Scenario,all_1_0,0.5940727641665847,Car,1,0,all,1km ≥ walking
+65plus,females and males,Scenario,all_1_0,0.002428777379515324,Other,1,0,all,1km ≥ walking
+65plus,females and males,Scenario,all_1_0,0.06168165206248378,Public transport,1,0,all,1km ≥ walking
+65plus,females and males,Scenario,all_1_0,0.3352012957906592,Walking,1,0,all,1km ≥ walking
+65plus,females and males,Scenario,commuting_1_0,0.006615510600756916,Cycling,1,0,commuting,1km ≥ walking
+65plus,females and males,Scenario,commuting_1_0,0.6406517432076146,Car,1,0,commuting,1km ≥ walking
+65plus,females and males,Scenario,commuting_1_0,0.002428777379515324,Other,1,0,commuting,1km ≥ walking
+65plus,females and males,Scenario,commuting_1_0,0.06168165206248378,Public transport,1,0,commuting,1km ≥ walking
+65plus,females and males,Scenario,commuting_1_0,0.2886223167496293,Walking,1,0,commuting,1km ≥ walking
+65plus,females and males,Scenario,all_1_2,0.1254111484536097,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Scenario,all_1_2,0.4752771263137319,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Scenario,all_1_2,0.002428777379515324,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Scenario,all_1_2,0.06168165206248378,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Scenario,all_1_2,0.3352012957906592,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Scenario,commuting_1_2,0.012190296534873664,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Scenario,commuting_1_2,0.6350769572734979,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Scenario,commuting_1_2,0.002428777379515324,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Scenario,commuting_1_2,0.06168165206248378,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Scenario,commuting_1_2,0.2886223167496293,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+65plus,females and males,Scenario,all_1_5,0.3236931178763377,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Scenario,all_1_5,0.2769951568910039,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Scenario,all_1_5,0.002428777379515324,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Scenario,all_1_5,0.06168165206248378,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Scenario,all_1_5,0.3352012957906592,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Scenario,commuting_1_5,0.020672688228052377,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Scenario,commuting_1_5,0.6265945655803192,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Scenario,commuting_1_5,0.002428777379515324,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Scenario,commuting_1_5,0.06168165206248378,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Scenario,commuting_1_5,0.2886223167496293,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+65plus,females and males,Scenario,all_2_0,0.006615510600756916,Cycling,2,0,all,2km ≥ walking
+65plus,females and males,Scenario,all_2_0,0.4752771263137319,Car,2,0,all,2km ≥ walking
+65plus,females and males,Scenario,all_2_0,0.002428777379515324,Other,2,0,all,2km ≥ walking
+65plus,females and males,Scenario,all_2_0,0.06168165206248378,Public transport,2,0,all,2km ≥ walking
+65plus,females and males,Scenario,all_2_0,0.453996933643512,Walking,2,0,all,2km ≥ walking
+65plus,females and males,Scenario,commuting_2_0,0.006615510600756916,Cycling,2,0,commuting,2km ≥ walking
+65plus,females and males,Scenario,commuting_2_0,0.6350769572734979,Car,2,0,commuting,2km ≥ walking
+65plus,females and males,Scenario,commuting_2_0,0.002428777379515324,Other,2,0,commuting,2km ≥ walking
+65plus,females and males,Scenario,commuting_2_0,0.06168165206248378,Public transport,2,0,commuting,2km ≥ walking
+65plus,females and males,Scenario,commuting_2_0,0.29419710268374605,Walking,2,0,commuting,2km ≥ walking
+65plus,females and males,Scenario,all_2_5,0.20489748002348496,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Scenario,all_2_5,0.2769951568910039,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Scenario,all_2_5,0.002428777379515324,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Scenario,all_2_5,0.06168165206248378,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Scenario,all_2_5,0.453996933643512,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Scenario,commuting_2_5,0.015097902293935627,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Scenario,commuting_2_5,0.6265945655803192,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Scenario,commuting_2_5,0.002428777379515324,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Scenario,commuting_2_5,0.06168165206248378,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+65plus,females and males,Scenario,commuting_2_5,0.29419710268374605,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Base case,all_0_2,0.02286585462215163,Cycling,0,2,all,2km ≥ cycling
+40-64,males,Base case,all_0_2,0.6872149008052976,Car,0,2,all,2km ≥ cycling
+40-64,males,Base case,all_0_2,0.009054477342954205,Other,0,2,all,2km ≥ cycling
+40-64,males,Base case,all_0_2,0.05931098365093093,Public transport,0,2,all,2km ≥ cycling
+40-64,males,Base case,all_0_2,0.22155378357866565,Walking,0,2,all,2km ≥ cycling
+40-64,males,Base case,commuting_0_2,0.02286585462215163,Cycling,0,2,commuting,2km ≥ cycling
+40-64,males,Base case,commuting_0_2,0.6872149008052976,Car,0,2,commuting,2km ≥ cycling
+40-64,males,Base case,commuting_0_2,0.009054477342954205,Other,0,2,commuting,2km ≥ cycling
+40-64,males,Base case,commuting_0_2,0.05931098365093093,Public transport,0,2,commuting,2km ≥ cycling
+40-64,males,Base case,commuting_0_2,0.22155378357866565,Walking,0,2,commuting,2km ≥ cycling
+40-64,males,Base case,all_0_5,0.02286585462215163,Cycling,0,5,all,5km ≥ cycling
+40-64,males,Base case,all_0_5,0.6872149008052976,Car,0,5,all,5km ≥ cycling
+40-64,males,Base case,all_0_5,0.009054477342954205,Other,0,5,all,5km ≥ cycling
+40-64,males,Base case,all_0_5,0.05931098365093093,Public transport,0,5,all,5km ≥ cycling
+40-64,males,Base case,all_0_5,0.22155378357866565,Walking,0,5,all,5km ≥ cycling
+40-64,males,Base case,commuting_0_5,0.02286585462215163,Cycling,0,5,commuting,5km ≥ cycling
+40-64,males,Base case,commuting_0_5,0.6872149008052976,Car,0,5,commuting,5km ≥ cycling
+40-64,males,Base case,commuting_0_5,0.009054477342954205,Other,0,5,commuting,5km ≥ cycling
+40-64,males,Base case,commuting_0_5,0.05931098365093093,Public transport,0,5,commuting,5km ≥ cycling
+40-64,males,Base case,commuting_0_5,0.22155378357866565,Walking,0,5,commuting,5km ≥ cycling
+40-64,males,Base case,all_1_0,0.02286585462215163,Cycling,1,0,all,1km ≥ walking
+40-64,males,Base case,all_1_0,0.6872149008052976,Car,1,0,all,1km ≥ walking
+40-64,males,Base case,all_1_0,0.009054477342954205,Other,1,0,all,1km ≥ walking
+40-64,males,Base case,all_1_0,0.05931098365093093,Public transport,1,0,all,1km ≥ walking
+40-64,males,Base case,all_1_0,0.22155378357866565,Walking,1,0,all,1km ≥ walking
+40-64,males,Base case,commuting_1_0,0.02286585462215163,Cycling,1,0,commuting,1km ≥ walking
+40-64,males,Base case,commuting_1_0,0.6872149008052976,Car,1,0,commuting,1km ≥ walking
+40-64,males,Base case,commuting_1_0,0.009054477342954205,Other,1,0,commuting,1km ≥ walking
+40-64,males,Base case,commuting_1_0,0.05931098365093093,Public transport,1,0,commuting,1km ≥ walking
+40-64,males,Base case,commuting_1_0,0.22155378357866565,Walking,1,0,commuting,1km ≥ walking
+40-64,males,Base case,all_1_2,0.02286585462215163,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Base case,all_1_2,0.6872149008052976,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Base case,all_1_2,0.009054477342954205,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Base case,all_1_2,0.05931098365093093,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Base case,all_1_2,0.22155378357866565,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Base case,commuting_1_2,0.02286585462215163,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Base case,commuting_1_2,0.6872149008052976,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Base case,commuting_1_2,0.009054477342954205,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Base case,commuting_1_2,0.05931098365093093,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Base case,commuting_1_2,0.22155378357866565,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Base case,all_1_5,0.02286585462215163,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Base case,all_1_5,0.6872149008052976,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Base case,all_1_5,0.009054477342954205,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Base case,all_1_5,0.05931098365093093,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Base case,all_1_5,0.22155378357866565,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Base case,commuting_1_5,0.02286585462215163,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Base case,commuting_1_5,0.6872149008052976,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Base case,commuting_1_5,0.009054477342954205,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Base case,commuting_1_5,0.05931098365093093,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Base case,commuting_1_5,0.22155378357866565,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Base case,all_2_0,0.02286585462215163,Cycling,2,0,all,2km ≥ walking
+40-64,males,Base case,all_2_0,0.6872149008052976,Car,2,0,all,2km ≥ walking
+40-64,males,Base case,all_2_0,0.009054477342954205,Other,2,0,all,2km ≥ walking
+40-64,males,Base case,all_2_0,0.05931098365093093,Public transport,2,0,all,2km ≥ walking
+40-64,males,Base case,all_2_0,0.22155378357866565,Walking,2,0,all,2km ≥ walking
+40-64,males,Base case,commuting_2_0,0.02286585462215163,Cycling,2,0,commuting,2km ≥ walking
+40-64,males,Base case,commuting_2_0,0.6872149008052976,Car,2,0,commuting,2km ≥ walking
+40-64,males,Base case,commuting_2_0,0.009054477342954205,Other,2,0,commuting,2km ≥ walking
+40-64,males,Base case,commuting_2_0,0.05931098365093093,Public transport,2,0,commuting,2km ≥ walking
+40-64,males,Base case,commuting_2_0,0.22155378357866565,Walking,2,0,commuting,2km ≥ walking
+40-64,males,Base case,all_2_5,0.02286585462215163,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Base case,all_2_5,0.6872149008052976,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Base case,all_2_5,0.009054477342954205,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Base case,all_2_5,0.05931098365093093,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Base case,all_2_5,0.22155378357866565,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Base case,commuting_2_5,0.02286585462215163,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Base case,commuting_2_5,0.6872149008052976,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Base case,commuting_2_5,0.009054477342954205,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Base case,commuting_2_5,0.05931098365093093,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Base case,commuting_2_5,0.22155378357866565,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Scenario,all_0_2,0.12253286988825306,Cycling,0,2,all,2km ≥ cycling
+40-64,males,Scenario,all_0_2,0.5875478855391961,Car,0,2,all,2km ≥ cycling
+40-64,males,Scenario,all_0_2,0.009054477342954205,Other,0,2,all,2km ≥ cycling
+40-64,males,Scenario,all_0_2,0.05931098365093093,Public transport,0,2,all,2km ≥ cycling
+40-64,males,Scenario,all_0_2,0.22155378357866565,Walking,0,2,all,2km ≥ cycling
+40-64,males,Scenario,commuting_0_2,0.03736415336672589,Cycling,0,2,commuting,2km ≥ cycling
+40-64,males,Scenario,commuting_0_2,0.6727166020607233,Car,0,2,commuting,2km ≥ cycling
+40-64,males,Scenario,commuting_0_2,0.009054477342954205,Other,0,2,commuting,2km ≥ cycling
+40-64,males,Scenario,commuting_0_2,0.05931098365093093,Public transport,0,2,commuting,2km ≥ cycling
+40-64,males,Scenario,commuting_0_2,0.22155378357866565,Walking,0,2,commuting,2km ≥ cycling
+40-64,males,Scenario,all_0_5,0.3086152597548316,Cycling,0,5,all,5km ≥ cycling
+40-64,males,Scenario,all_0_5,0.4014654956726176,Car,0,5,all,5km ≥ cycling
+40-64,males,Scenario,all_0_5,0.009054477342954205,Other,0,5,all,5km ≥ cycling
+40-64,males,Scenario,all_0_5,0.05931098365093093,Public transport,0,5,all,5km ≥ cycling
+40-64,males,Scenario,all_0_5,0.22155378357866565,Walking,0,5,all,5km ≥ cycling
+40-64,males,Scenario,commuting_0_5,0.06381062188209054,Cycling,0,5,commuting,5km ≥ cycling
+40-64,males,Scenario,commuting_0_5,0.6462701335453587,Car,0,5,commuting,5km ≥ cycling
+40-64,males,Scenario,commuting_0_5,0.009054477342954205,Other,0,5,commuting,5km ≥ cycling
+40-64,males,Scenario,commuting_0_5,0.05931098365093093,Public transport,0,5,commuting,5km ≥ cycling
+40-64,males,Scenario,commuting_0_5,0.22155378357866565,Walking,0,5,commuting,5km ≥ cycling
+40-64,males,Scenario,all_1_0,0.02286585462215163,Cycling,1,0,all,1km ≥ walking
+40-64,males,Scenario,all_1_0,0.6566579816016871,Car,1,0,all,1km ≥ walking
+40-64,males,Scenario,all_1_0,0.009054477342954205,Other,1,0,all,1km ≥ walking
+40-64,males,Scenario,all_1_0,0.05931098365093093,Public transport,1,0,all,1km ≥ walking
+40-64,males,Scenario,all_1_0,0.2521107027822761,Walking,1,0,all,1km ≥ walking
+40-64,males,Scenario,commuting_1_0,0.02286585462215163,Cycling,1,0,commuting,1km ≥ walking
+40-64,males,Scenario,commuting_1_0,0.6824119658947372,Car,1,0,commuting,1km ≥ walking
+40-64,males,Scenario,commuting_1_0,0.009054477342954205,Other,1,0,commuting,1km ≥ walking
+40-64,males,Scenario,commuting_1_0,0.05931098365093093,Public transport,1,0,commuting,1km ≥ walking
+40-64,males,Scenario,commuting_1_0,0.226356718489226,Walking,1,0,commuting,1km ≥ walking
+40-64,males,Scenario,all_1_2,0.09197595068464264,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Scenario,all_1_2,0.5875478855391961,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Scenario,all_1_2,0.009054477342954205,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Scenario,all_1_2,0.05931098365093093,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Scenario,all_1_2,0.2521107027822761,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Scenario,commuting_1_2,0.03256121845616554,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Scenario,commuting_1_2,0.6727166020607233,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Scenario,commuting_1_2,0.009054477342954205,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Scenario,commuting_1_2,0.05931098365093093,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Scenario,commuting_1_2,0.226356718489226,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,males,Scenario,all_1_5,0.27805834055122114,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Scenario,all_1_5,0.4014654956726176,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Scenario,all_1_5,0.009054477342954205,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Scenario,all_1_5,0.05931098365093093,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Scenario,all_1_5,0.2521107027822761,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Scenario,commuting_1_5,0.059007686971530186,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Scenario,commuting_1_5,0.6462701335453587,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Scenario,commuting_1_5,0.009054477342954205,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Scenario,commuting_1_5,0.05931098365093093,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Scenario,commuting_1_5,0.226356718489226,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,males,Scenario,all_2_0,0.02286585462215163,Cycling,2,0,all,2km ≥ walking
+40-64,males,Scenario,all_2_0,0.5875478855391961,Car,2,0,all,2km ≥ walking
+40-64,males,Scenario,all_2_0,0.009054477342954205,Other,2,0,all,2km ≥ walking
+40-64,males,Scenario,all_2_0,0.05931098365093093,Public transport,2,0,all,2km ≥ walking
+40-64,males,Scenario,all_2_0,0.32122079884476706,Walking,2,0,all,2km ≥ walking
+40-64,males,Scenario,commuting_2_0,0.02286585462215163,Cycling,2,0,commuting,2km ≥ walking
+40-64,males,Scenario,commuting_2_0,0.6727166020607233,Car,2,0,commuting,2km ≥ walking
+40-64,males,Scenario,commuting_2_0,0.009054477342954205,Other,2,0,commuting,2km ≥ walking
+40-64,males,Scenario,commuting_2_0,0.05931098365093093,Public transport,2,0,commuting,2km ≥ walking
+40-64,males,Scenario,commuting_2_0,0.2360520823232399,Walking,2,0,commuting,2km ≥ walking
+40-64,males,Scenario,all_2_5,0.20894824448873017,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Scenario,all_2_5,0.4014654956726176,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Scenario,all_2_5,0.009054477342954205,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Scenario,all_2_5,0.05931098365093093,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Scenario,all_2_5,0.32122079884476706,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Scenario,commuting_2_5,0.04931232313751628,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Scenario,commuting_2_5,0.6462701335453587,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Scenario,commuting_2_5,0.009054477342954205,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Scenario,commuting_2_5,0.05931098365093093,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,males,Scenario,commuting_2_5,0.2360520823232399,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Base case,all_0_2,0.007177510996773656,Cycling,0,2,all,2km ≥ cycling
+40-64,females,Base case,all_0_2,0.7015005105975187,Car,0,2,all,2km ≥ cycling
+40-64,females,Base case,all_0_2,0.008184325827553919,Other,0,2,all,2km ≥ cycling
+40-64,females,Base case,all_0_2,0.04445498307913608,Public transport,0,2,all,2km ≥ cycling
+40-64,females,Base case,all_0_2,0.23868266949901765,Walking,0,2,all,2km ≥ cycling
+40-64,females,Base case,commuting_0_2,0.007177510996773656,Cycling,0,2,commuting,2km ≥ cycling
+40-64,females,Base case,commuting_0_2,0.7015005105975187,Car,0,2,commuting,2km ≥ cycling
+40-64,females,Base case,commuting_0_2,0.008184325827553919,Other,0,2,commuting,2km ≥ cycling
+40-64,females,Base case,commuting_0_2,0.04445498307913608,Public transport,0,2,commuting,2km ≥ cycling
+40-64,females,Base case,commuting_0_2,0.23868266949901765,Walking,0,2,commuting,2km ≥ cycling
+40-64,females,Base case,all_0_5,0.007177510996773656,Cycling,0,5,all,5km ≥ cycling
+40-64,females,Base case,all_0_5,0.7015005105975187,Car,0,5,all,5km ≥ cycling
+40-64,females,Base case,all_0_5,0.008184325827553919,Other,0,5,all,5km ≥ cycling
+40-64,females,Base case,all_0_5,0.04445498307913608,Public transport,0,5,all,5km ≥ cycling
+40-64,females,Base case,all_0_5,0.23868266949901765,Walking,0,5,all,5km ≥ cycling
+40-64,females,Base case,commuting_0_5,0.007177510996773656,Cycling,0,5,commuting,5km ≥ cycling
+40-64,females,Base case,commuting_0_5,0.7015005105975187,Car,0,5,commuting,5km ≥ cycling
+40-64,females,Base case,commuting_0_5,0.008184325827553919,Other,0,5,commuting,5km ≥ cycling
+40-64,females,Base case,commuting_0_5,0.04445498307913608,Public transport,0,5,commuting,5km ≥ cycling
+40-64,females,Base case,commuting_0_5,0.23868266949901765,Walking,0,5,commuting,5km ≥ cycling
+40-64,females,Base case,all_1_0,0.007177510996773656,Cycling,1,0,all,1km ≥ walking
+40-64,females,Base case,all_1_0,0.7015005105975187,Car,1,0,all,1km ≥ walking
+40-64,females,Base case,all_1_0,0.008184325827553919,Other,1,0,all,1km ≥ walking
+40-64,females,Base case,all_1_0,0.04445498307913608,Public transport,1,0,all,1km ≥ walking
+40-64,females,Base case,all_1_0,0.23868266949901765,Walking,1,0,all,1km ≥ walking
+40-64,females,Base case,commuting_1_0,0.007177510996773656,Cycling,1,0,commuting,1km ≥ walking
+40-64,females,Base case,commuting_1_0,0.7015005105975187,Car,1,0,commuting,1km ≥ walking
+40-64,females,Base case,commuting_1_0,0.008184325827553919,Other,1,0,commuting,1km ≥ walking
+40-64,females,Base case,commuting_1_0,0.04445498307913608,Public transport,1,0,commuting,1km ≥ walking
+40-64,females,Base case,commuting_1_0,0.23868266949901765,Walking,1,0,commuting,1km ≥ walking
+40-64,females,Base case,all_1_2,0.007177510996773656,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Base case,all_1_2,0.7015005105975187,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Base case,all_1_2,0.008184325827553919,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Base case,all_1_2,0.04445498307913608,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Base case,all_1_2,0.23868266949901765,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Base case,commuting_1_2,0.007177510996773656,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Base case,commuting_1_2,0.7015005105975187,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Base case,commuting_1_2,0.008184325827553919,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Base case,commuting_1_2,0.04445498307913608,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Base case,commuting_1_2,0.23868266949901765,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Base case,all_1_5,0.007177510996773656,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Base case,all_1_5,0.7015005105975187,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Base case,all_1_5,0.008184325827553919,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Base case,all_1_5,0.04445498307913608,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Base case,all_1_5,0.23868266949901765,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Base case,commuting_1_5,0.007177510996773656,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Base case,commuting_1_5,0.7015005105975187,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Base case,commuting_1_5,0.008184325827553919,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Base case,commuting_1_5,0.04445498307913608,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Base case,commuting_1_5,0.23868266949901765,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Base case,all_2_0,0.007177510996773656,Cycling,2,0,all,2km ≥ walking
+40-64,females,Base case,all_2_0,0.7015005105975187,Car,2,0,all,2km ≥ walking
+40-64,females,Base case,all_2_0,0.008184325827553919,Other,2,0,all,2km ≥ walking
+40-64,females,Base case,all_2_0,0.04445498307913608,Public transport,2,0,all,2km ≥ walking
+40-64,females,Base case,all_2_0,0.23868266949901765,Walking,2,0,all,2km ≥ walking
+40-64,females,Base case,commuting_2_0,0.007177510996773656,Cycling,2,0,commuting,2km ≥ walking
+40-64,females,Base case,commuting_2_0,0.7015005105975187,Car,2,0,commuting,2km ≥ walking
+40-64,females,Base case,commuting_2_0,0.008184325827553919,Other,2,0,commuting,2km ≥ walking
+40-64,females,Base case,commuting_2_0,0.04445498307913608,Public transport,2,0,commuting,2km ≥ walking
+40-64,females,Base case,commuting_2_0,0.23868266949901765,Walking,2,0,commuting,2km ≥ walking
+40-64,females,Base case,all_2_5,0.007177510996773656,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Base case,all_2_5,0.7015005105975187,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Base case,all_2_5,0.008184325827553919,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Base case,all_2_5,0.04445498307913608,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Base case,all_2_5,0.23868266949901765,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Base case,commuting_2_5,0.007177510996773656,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Base case,commuting_2_5,0.7015005105975187,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Base case,commuting_2_5,0.008184325827553919,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Base case,commuting_2_5,0.04445498307913608,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Base case,commuting_2_5,0.23868266949901765,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Scenario,all_0_2,0.127186669939949,Cycling,0,2,all,2km ≥ cycling
+40-64,females,Scenario,all_0_2,0.5814913516543434,Car,0,2,all,2km ≥ cycling
+40-64,females,Scenario,all_0_2,0.008184325827553919,Other,0,2,all,2km ≥ cycling
+40-64,females,Scenario,all_0_2,0.04445498307913608,Public transport,0,2,all,2km ≥ cycling
+40-64,females,Scenario,all_0_2,0.23868266949901765,Walking,0,2,all,2km ≥ cycling
+40-64,females,Scenario,commuting_0_2,0.02010255784572976,Cycling,0,2,commuting,2km ≥ cycling
+40-64,females,Scenario,commuting_0_2,0.6885754637485626,Car,0,2,commuting,2km ≥ cycling
+40-64,females,Scenario,commuting_0_2,0.008184325827553919,Other,0,2,commuting,2km ≥ cycling
+40-64,females,Scenario,commuting_0_2,0.04445498307913608,Public transport,0,2,commuting,2km ≥ cycling
+40-64,females,Scenario,commuting_0_2,0.23868266949901765,Walking,0,2,commuting,2km ≥ cycling
+40-64,females,Scenario,all_0_5,0.33237359967921504,Cycling,0,5,all,5km ≥ cycling
+40-64,females,Scenario,all_0_5,0.37630442191507735,Car,0,5,all,5km ≥ cycling
+40-64,females,Scenario,all_0_5,0.008184325827553919,Other,0,5,all,5km ≥ cycling
+40-64,females,Scenario,all_0_5,0.04445498307913608,Public transport,0,5,all,5km ≥ cycling
+40-64,females,Scenario,all_0_5,0.23868266949901765,Walking,0,5,all,5km ≥ cycling
+40-64,females,Scenario,commuting_0_5,0.043753081032479726,Cycling,0,5,commuting,5km ≥ cycling
+40-64,females,Scenario,commuting_0_5,0.6649249405618126,Car,0,5,commuting,5km ≥ cycling
+40-64,females,Scenario,commuting_0_5,0.008184325827553919,Other,0,5,commuting,5km ≥ cycling
+40-64,females,Scenario,commuting_0_5,0.04445498307913608,Public transport,0,5,commuting,5km ≥ cycling
+40-64,females,Scenario,commuting_0_5,0.23868266949901765,Walking,0,5,commuting,5km ≥ cycling
+40-64,females,Scenario,all_1_0,0.007177510996773656,Cycling,1,0,all,1km ≥ walking
+40-64,females,Scenario,all_1_0,0.6692505930255412,Car,1,0,all,1km ≥ walking
+40-64,females,Scenario,all_1_0,0.008184325827553919,Other,1,0,all,1km ≥ walking
+40-64,females,Scenario,all_1_0,0.04445498307913608,Public transport,1,0,all,1km ≥ walking
+40-64,females,Scenario,all_1_0,0.27093258707099516,Walking,1,0,all,1km ≥ walking
+40-64,females,Scenario,commuting_1_0,0.007177510996773656,Cycling,1,0,commuting,1km ≥ walking
+40-64,females,Scenario,commuting_1_0,0.6977824025974506,Car,1,0,commuting,1km ≥ walking
+40-64,females,Scenario,commuting_1_0,0.008184325827553919,Other,1,0,commuting,1km ≥ walking
+40-64,females,Scenario,commuting_1_0,0.04445498307913608,Public transport,1,0,commuting,1km ≥ walking
+40-64,females,Scenario,commuting_1_0,0.24240077749908573,Walking,1,0,commuting,1km ≥ walking
+40-64,females,Scenario,all_1_2,0.09493675236797151,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Scenario,all_1_2,0.5814913516543434,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Scenario,all_1_2,0.008184325827553919,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Scenario,all_1_2,0.04445498307913608,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Scenario,all_1_2,0.27093258707099516,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Scenario,commuting_1_2,0.016384449845661696,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Scenario,commuting_1_2,0.6885754637485626,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Scenario,commuting_1_2,0.008184325827553919,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Scenario,commuting_1_2,0.04445498307913608,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Scenario,commuting_1_2,0.24240077749908573,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females,Scenario,all_1_5,0.30012368210723755,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Scenario,all_1_5,0.37630442191507735,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Scenario,all_1_5,0.008184325827553919,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Scenario,all_1_5,0.04445498307913608,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Scenario,all_1_5,0.27093258707099516,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Scenario,commuting_1_5,0.040034973032411665,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Scenario,commuting_1_5,0.6649249405618126,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Scenario,commuting_1_5,0.008184325827553919,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Scenario,commuting_1_5,0.04445498307913608,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Scenario,commuting_1_5,0.24240077749908573,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females,Scenario,all_2_0,0.007177510996773656,Cycling,2,0,all,2km ≥ walking
+40-64,females,Scenario,all_2_0,0.5814913516543434,Car,2,0,all,2km ≥ walking
+40-64,females,Scenario,all_2_0,0.008184325827553919,Other,2,0,all,2km ≥ walking
+40-64,females,Scenario,all_2_0,0.04445498307913608,Public transport,2,0,all,2km ≥ walking
+40-64,females,Scenario,all_2_0,0.358691828442193,Walking,2,0,all,2km ≥ walking
+40-64,females,Scenario,commuting_2_0,0.007177510996773656,Cycling,2,0,commuting,2km ≥ walking
+40-64,females,Scenario,commuting_2_0,0.6885754637485626,Car,2,0,commuting,2km ≥ walking
+40-64,females,Scenario,commuting_2_0,0.008184325827553919,Other,2,0,commuting,2km ≥ walking
+40-64,females,Scenario,commuting_2_0,0.04445498307913608,Public transport,2,0,commuting,2km ≥ walking
+40-64,females,Scenario,commuting_2_0,0.25160771634797374,Walking,2,0,commuting,2km ≥ walking
+40-64,females,Scenario,all_2_5,0.21236444073603972,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Scenario,all_2_5,0.37630442191507735,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Scenario,all_2_5,0.008184325827553919,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Scenario,all_2_5,0.04445498307913608,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Scenario,all_2_5,0.358691828442193,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Scenario,commuting_2_5,0.03082803418352362,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Scenario,commuting_2_5,0.6649249405618126,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Scenario,commuting_2_5,0.008184325827553919,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Scenario,commuting_2_5,0.04445498307913608,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females,Scenario,commuting_2_5,0.25160771634797374,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Base case,all_0_2,0.014923576389870744,Cycling,0,2,all,2km ≥ cycling
+40-64,females and males,Base case,all_0_2,0.6944470401819542,Car,0,2,all,2km ≥ cycling
+40-64,females and males,Base case,all_0_2,0.008613960128098553,Other,0,2,all,2km ≥ cycling
+40-64,females and males,Base case,all_0_2,0.05179008196891694,Public transport,0,2,all,2km ≥ cycling
+40-64,females and males,Base case,all_0_2,0.23022534133115954,Walking,0,2,all,2km ≥ cycling
+40-64,females and males,Base case,commuting_0_2,0.014923576389870744,Cycling,0,2,commuting,2km ≥ cycling
+40-64,females and males,Base case,commuting_0_2,0.6944470401819542,Car,0,2,commuting,2km ≥ cycling
+40-64,females and males,Base case,commuting_0_2,0.008613960128098553,Other,0,2,commuting,2km ≥ cycling
+40-64,females and males,Base case,commuting_0_2,0.05179008196891694,Public transport,0,2,commuting,2km ≥ cycling
+40-64,females and males,Base case,commuting_0_2,0.23022534133115954,Walking,0,2,commuting,2km ≥ cycling
+40-64,females and males,Base case,all_0_5,0.014923576389870744,Cycling,0,5,all,5km ≥ cycling
+40-64,females and males,Base case,all_0_5,0.6944470401819542,Car,0,5,all,5km ≥ cycling
+40-64,females and males,Base case,all_0_5,0.008613960128098553,Other,0,5,all,5km ≥ cycling
+40-64,females and males,Base case,all_0_5,0.05179008196891694,Public transport,0,5,all,5km ≥ cycling
+40-64,females and males,Base case,all_0_5,0.23022534133115954,Walking,0,5,all,5km ≥ cycling
+40-64,females and males,Base case,commuting_0_5,0.014923576389870744,Cycling,0,5,commuting,5km ≥ cycling
+40-64,females and males,Base case,commuting_0_5,0.6944470401819542,Car,0,5,commuting,5km ≥ cycling
+40-64,females and males,Base case,commuting_0_5,0.008613960128098553,Other,0,5,commuting,5km ≥ cycling
+40-64,females and males,Base case,commuting_0_5,0.05179008196891694,Public transport,0,5,commuting,5km ≥ cycling
+40-64,females and males,Base case,commuting_0_5,0.23022534133115954,Walking,0,5,commuting,5km ≥ cycling
+40-64,females and males,Base case,all_1_0,0.014923576389870744,Cycling,1,0,all,1km ≥ walking
+40-64,females and males,Base case,all_1_0,0.6944470401819542,Car,1,0,all,1km ≥ walking
+40-64,females and males,Base case,all_1_0,0.008613960128098553,Other,1,0,all,1km ≥ walking
+40-64,females and males,Base case,all_1_0,0.05179008196891694,Public transport,1,0,all,1km ≥ walking
+40-64,females and males,Base case,all_1_0,0.23022534133115954,Walking,1,0,all,1km ≥ walking
+40-64,females and males,Base case,commuting_1_0,0.014923576389870744,Cycling,1,0,commuting,1km ≥ walking
+40-64,females and males,Base case,commuting_1_0,0.6944470401819542,Car,1,0,commuting,1km ≥ walking
+40-64,females and males,Base case,commuting_1_0,0.008613960128098553,Other,1,0,commuting,1km ≥ walking
+40-64,females and males,Base case,commuting_1_0,0.05179008196891694,Public transport,1,0,commuting,1km ≥ walking
+40-64,females and males,Base case,commuting_1_0,0.23022534133115954,Walking,1,0,commuting,1km ≥ walking
+40-64,females and males,Base case,all_1_2,0.014923576389870744,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Base case,all_1_2,0.6944470401819542,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Base case,all_1_2,0.008613960128098553,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Base case,all_1_2,0.05179008196891694,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Base case,all_1_2,0.23022534133115954,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Base case,commuting_1_2,0.014923576389870744,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Base case,commuting_1_2,0.6944470401819542,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Base case,commuting_1_2,0.008613960128098553,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Base case,commuting_1_2,0.05179008196891694,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Base case,commuting_1_2,0.23022534133115954,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Base case,all_1_5,0.014923576389870744,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Base case,all_1_5,0.6944470401819542,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Base case,all_1_5,0.008613960128098553,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Base case,all_1_5,0.05179008196891694,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Base case,all_1_5,0.23022534133115954,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Base case,commuting_1_5,0.014923576389870744,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Base case,commuting_1_5,0.6944470401819542,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Base case,commuting_1_5,0.008613960128098553,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Base case,commuting_1_5,0.05179008196891694,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Base case,commuting_1_5,0.23022534133115954,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Base case,all_2_0,0.014923576389870744,Cycling,2,0,all,2km ≥ walking
+40-64,females and males,Base case,all_2_0,0.6944470401819542,Car,2,0,all,2km ≥ walking
+40-64,females and males,Base case,all_2_0,0.008613960128098553,Other,2,0,all,2km ≥ walking
+40-64,females and males,Base case,all_2_0,0.05179008196891694,Public transport,2,0,all,2km ≥ walking
+40-64,females and males,Base case,all_2_0,0.23022534133115954,Walking,2,0,all,2km ≥ walking
+40-64,females and males,Base case,commuting_2_0,0.014923576389870744,Cycling,2,0,commuting,2km ≥ walking
+40-64,females and males,Base case,commuting_2_0,0.6944470401819542,Car,2,0,commuting,2km ≥ walking
+40-64,females and males,Base case,commuting_2_0,0.008613960128098553,Other,2,0,commuting,2km ≥ walking
+40-64,females and males,Base case,commuting_2_0,0.05179008196891694,Public transport,2,0,commuting,2km ≥ walking
+40-64,females and males,Base case,commuting_2_0,0.23022534133115954,Walking,2,0,commuting,2km ≥ walking
+40-64,females and males,Base case,all_2_5,0.014923576389870744,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Base case,all_2_5,0.6944470401819542,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Base case,all_2_5,0.008613960128098553,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Base case,all_2_5,0.05179008196891694,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Base case,all_2_5,0.23022534133115954,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Base case,commuting_2_5,0.014923576389870744,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Base case,commuting_2_5,0.6944470401819542,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Base case,commuting_2_5,0.008613960128098553,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Base case,commuting_2_5,0.05179008196891694,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Base case,commuting_2_5,0.23022534133115954,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Scenario,all_0_2,0.12488887226368432,Cycling,0,2,all,2km ≥ cycling
+40-64,females and males,Scenario,all_0_2,0.5844817443081407,Car,0,2,all,2km ≥ cycling
+40-64,females and males,Scenario,all_0_2,0.008613960128098553,Other,0,2,all,2km ≥ cycling
+40-64,females and males,Scenario,all_0_2,0.05179008196891694,Public transport,0,2,all,2km ≥ cycling
+40-64,females and males,Scenario,all_0_2,0.23022534133115954,Walking,0,2,all,2km ≥ cycling
+40-64,females and males,Scenario,commuting_0_2,0.02862541091981306,Cycling,0,2,commuting,2km ≥ cycling
+40-64,females and males,Scenario,commuting_0_2,0.6807452056520119,Car,0,2,commuting,2km ≥ cycling
+40-64,females and males,Scenario,commuting_0_2,0.008613960128098553,Other,0,2,commuting,2km ≥ cycling
+40-64,females and males,Scenario,commuting_0_2,0.05179008196891694,Public transport,0,2,commuting,2km ≥ cycling
+40-64,females and males,Scenario,commuting_0_2,0.23022534133115954,Walking,0,2,commuting,2km ≥ cycling
+40-64,females and males,Scenario,all_0_5,0.3206430015306632,Cycling,0,5,all,5km ≥ cycling
+40-64,females and males,Scenario,all_0_5,0.38872761504116177,Car,0,5,all,5km ≥ cycling
+40-64,females and males,Scenario,all_0_5,0.008613960128098553,Other,0,5,all,5km ≥ cycling
+40-64,females and males,Scenario,all_0_5,0.05179008196891694,Public transport,0,5,all,5km ≥ cycling
+40-64,females and males,Scenario,all_0_5,0.23022534133115954,Walking,0,5,all,5km ≥ cycling
+40-64,females and males,Scenario,commuting_0_5,0.05365642244033076,Cycling,0,5,commuting,5km ≥ cycling
+40-64,females and males,Scenario,commuting_0_5,0.6557141941314942,Car,0,5,commuting,5km ≥ cycling
+40-64,females and males,Scenario,commuting_0_5,0.008613960128098553,Other,0,5,commuting,5km ≥ cycling
+40-64,females and males,Scenario,commuting_0_5,0.05179008196891694,Public transport,0,5,commuting,5km ≥ cycling
+40-64,females and males,Scenario,commuting_0_5,0.23022534133115954,Walking,0,5,commuting,5km ≥ cycling
+40-64,females and males,Scenario,all_1_0,0.014923576389870744,Cycling,1,0,all,1km ≥ walking
+40-64,females and males,Scenario,all_1_0,0.6630330346976342,Car,1,0,all,1km ≥ walking
+40-64,females and males,Scenario,all_1_0,0.008613960128098553,Other,1,0,all,1km ≥ walking
+40-64,females and males,Scenario,all_1_0,0.05179008196891694,Public transport,1,0,all,1km ≥ walking
+40-64,females and males,Scenario,all_1_0,0.2616393468154795,Walking,1,0,all,1km ≥ walking
+40-64,females and males,Scenario,commuting_1_0,0.014923576389870744,Cycling,1,0,commuting,1km ≥ walking
+40-64,females and males,Scenario,commuting_1_0,0.6901933026476585,Car,1,0,commuting,1km ≥ walking
+40-64,females and males,Scenario,commuting_1_0,0.008613960128098553,Other,1,0,commuting,1km ≥ walking
+40-64,females and males,Scenario,commuting_1_0,0.05179008196891694,Public transport,1,0,commuting,1km ≥ walking
+40-64,females and males,Scenario,commuting_1_0,0.23447907886545527,Walking,1,0,commuting,1km ≥ walking
+40-64,females and males,Scenario,all_1_2,0.09347486677936433,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Scenario,all_1_2,0.5844817443081407,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Scenario,all_1_2,0.008613960128098553,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Scenario,all_1_2,0.05179008196891694,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Scenario,all_1_2,0.2616393468154795,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Scenario,commuting_1_2,0.024371673385517333,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Scenario,commuting_1_2,0.6807452056520119,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Scenario,commuting_1_2,0.008613960128098553,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Scenario,commuting_1_2,0.05179008196891694,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Scenario,commuting_1_2,0.23447907886545527,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+40-64,females and males,Scenario,all_1_5,0.2892289960463432,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Scenario,all_1_5,0.38872761504116177,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Scenario,all_1_5,0.008613960128098553,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Scenario,all_1_5,0.05179008196891694,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Scenario,all_1_5,0.2616393468154795,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Scenario,commuting_1_5,0.049402684906035034,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Scenario,commuting_1_5,0.6557141941314942,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Scenario,commuting_1_5,0.008613960128098553,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Scenario,commuting_1_5,0.05179008196891694,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Scenario,commuting_1_5,0.23447907886545527,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+40-64,females and males,Scenario,all_2_0,0.014923576389870744,Cycling,2,0,all,2km ≥ walking
+40-64,females and males,Scenario,all_2_0,0.5844817443081407,Car,2,0,all,2km ≥ walking
+40-64,females and males,Scenario,all_2_0,0.008613960128098553,Other,2,0,all,2km ≥ walking
+40-64,females and males,Scenario,all_2_0,0.05179008196891694,Public transport,2,0,all,2km ≥ walking
+40-64,females and males,Scenario,all_2_0,0.3401906372049731,Walking,2,0,all,2km ≥ walking
+40-64,females and males,Scenario,commuting_2_0,0.014923576389870744,Cycling,2,0,commuting,2km ≥ walking
+40-64,females and males,Scenario,commuting_2_0,0.6807452056520119,Car,2,0,commuting,2km ≥ walking
+40-64,females and males,Scenario,commuting_2_0,0.008613960128098553,Other,2,0,commuting,2km ≥ walking
+40-64,females and males,Scenario,commuting_2_0,0.05179008196891694,Public transport,2,0,commuting,2km ≥ walking
+40-64,females and males,Scenario,commuting_2_0,0.24392717586110185,Walking,2,0,commuting,2km ≥ walking
+40-64,females and males,Scenario,all_2_5,0.21067770565684965,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Scenario,all_2_5,0.38872761504116177,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Scenario,all_2_5,0.008613960128098553,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Scenario,all_2_5,0.05179008196891694,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Scenario,all_2_5,0.3401906372049731,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Scenario,commuting_2_5,0.039954587910388445,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Scenario,commuting_2_5,0.6557141941314942,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Scenario,commuting_2_5,0.008613960128098553,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Scenario,commuting_2_5,0.05179008196891694,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+40-64,females and males,Scenario,commuting_2_5,0.24392717586110185,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Base case,all_0_2,0.024795358204530115,Cycling,0,2,all,2km ≥ cycling
+15-19,males,Base case,all_0_2,0.4394767375549712,Car,0,2,all,2km ≥ cycling
+15-19,males,Base case,all_0_2,0.014442947613094524,Other,0,2,all,2km ≥ cycling
+15-19,males,Base case,all_0_2,0.17951866036840639,Public transport,0,2,all,2km ≥ cycling
+15-19,males,Base case,all_0_2,0.34176629625899774,Walking,0,2,all,2km ≥ cycling
+15-19,males,Base case,commuting_0_2,0.024795358204530115,Cycling,0,2,commuting,2km ≥ cycling
+15-19,males,Base case,commuting_0_2,0.4394767375549712,Car,0,2,commuting,2km ≥ cycling
+15-19,males,Base case,commuting_0_2,0.014442947613094524,Other,0,2,commuting,2km ≥ cycling
+15-19,males,Base case,commuting_0_2,0.17951866036840639,Public transport,0,2,commuting,2km ≥ cycling
+15-19,males,Base case,commuting_0_2,0.34176629625899774,Walking,0,2,commuting,2km ≥ cycling
+15-19,males,Base case,all_0_5,0.024795358204530115,Cycling,0,5,all,5km ≥ cycling
+15-19,males,Base case,all_0_5,0.4394767375549712,Car,0,5,all,5km ≥ cycling
+15-19,males,Base case,all_0_5,0.014442947613094524,Other,0,5,all,5km ≥ cycling
+15-19,males,Base case,all_0_5,0.17951866036840639,Public transport,0,5,all,5km ≥ cycling
+15-19,males,Base case,all_0_5,0.34176629625899774,Walking,0,5,all,5km ≥ cycling
+15-19,males,Base case,commuting_0_5,0.024795358204530115,Cycling,0,5,commuting,5km ≥ cycling
+15-19,males,Base case,commuting_0_5,0.4394767375549712,Car,0,5,commuting,5km ≥ cycling
+15-19,males,Base case,commuting_0_5,0.014442947613094524,Other,0,5,commuting,5km ≥ cycling
+15-19,males,Base case,commuting_0_5,0.17951866036840639,Public transport,0,5,commuting,5km ≥ cycling
+15-19,males,Base case,commuting_0_5,0.34176629625899774,Walking,0,5,commuting,5km ≥ cycling
+15-19,males,Base case,all_1_0,0.024795358204530115,Cycling,1,0,all,1km ≥ walking
+15-19,males,Base case,all_1_0,0.4394767375549712,Car,1,0,all,1km ≥ walking
+15-19,males,Base case,all_1_0,0.014442947613094524,Other,1,0,all,1km ≥ walking
+15-19,males,Base case,all_1_0,0.17951866036840639,Public transport,1,0,all,1km ≥ walking
+15-19,males,Base case,all_1_0,0.34176629625899774,Walking,1,0,all,1km ≥ walking
+15-19,males,Base case,commuting_1_0,0.024795358204530115,Cycling,1,0,commuting,1km ≥ walking
+15-19,males,Base case,commuting_1_0,0.4394767375549712,Car,1,0,commuting,1km ≥ walking
+15-19,males,Base case,commuting_1_0,0.014442947613094524,Other,1,0,commuting,1km ≥ walking
+15-19,males,Base case,commuting_1_0,0.17951866036840639,Public transport,1,0,commuting,1km ≥ walking
+15-19,males,Base case,commuting_1_0,0.34176629625899774,Walking,1,0,commuting,1km ≥ walking
+15-19,males,Base case,all_1_2,0.024795358204530115,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Base case,all_1_2,0.4394767375549712,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Base case,all_1_2,0.014442947613094524,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Base case,all_1_2,0.17951866036840639,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Base case,all_1_2,0.34176629625899774,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Base case,commuting_1_2,0.024795358204530115,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Base case,commuting_1_2,0.4394767375549712,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Base case,commuting_1_2,0.014442947613094524,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Base case,commuting_1_2,0.17951866036840639,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Base case,commuting_1_2,0.34176629625899774,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Base case,all_1_5,0.024795358204530115,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Base case,all_1_5,0.4394767375549712,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Base case,all_1_5,0.014442947613094524,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Base case,all_1_5,0.17951866036840639,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Base case,all_1_5,0.34176629625899774,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Base case,commuting_1_5,0.024795358204530115,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Base case,commuting_1_5,0.4394767375549712,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Base case,commuting_1_5,0.014442947613094524,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Base case,commuting_1_5,0.17951866036840639,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Base case,commuting_1_5,0.34176629625899774,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Base case,all_2_0,0.024795358204530115,Cycling,2,0,all,2km ≥ walking
+15-19,males,Base case,all_2_0,0.4394767375549712,Car,2,0,all,2km ≥ walking
+15-19,males,Base case,all_2_0,0.014442947613094524,Other,2,0,all,2km ≥ walking
+15-19,males,Base case,all_2_0,0.17951866036840639,Public transport,2,0,all,2km ≥ walking
+15-19,males,Base case,all_2_0,0.34176629625899774,Walking,2,0,all,2km ≥ walking
+15-19,males,Base case,commuting_2_0,0.024795358204530115,Cycling,2,0,commuting,2km ≥ walking
+15-19,males,Base case,commuting_2_0,0.4394767375549712,Car,2,0,commuting,2km ≥ walking
+15-19,males,Base case,commuting_2_0,0.014442947613094524,Other,2,0,commuting,2km ≥ walking
+15-19,males,Base case,commuting_2_0,0.17951866036840639,Public transport,2,0,commuting,2km ≥ walking
+15-19,males,Base case,commuting_2_0,0.34176629625899774,Walking,2,0,commuting,2km ≥ walking
+15-19,males,Base case,all_2_5,0.024795358204530115,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Base case,all_2_5,0.4394767375549712,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Base case,all_2_5,0.014442947613094524,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Base case,all_2_5,0.17951866036840639,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Base case,all_2_5,0.34176629625899774,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Base case,commuting_2_5,0.024795358204530115,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Base case,commuting_2_5,0.4394767375549712,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Base case,commuting_2_5,0.014442947613094524,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Base case,commuting_2_5,0.17951866036840639,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Base case,commuting_2_5,0.34176629625899774,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Scenario,all_0_2,0.06046104416074357,Cycling,0,2,all,2km ≥ cycling
+15-19,males,Scenario,all_0_2,0.40381105159875774,Car,0,2,all,2km ≥ cycling
+15-19,males,Scenario,all_0_2,0.014442947613094524,Other,0,2,all,2km ≥ cycling
+15-19,males,Scenario,all_0_2,0.17951866036840639,Public transport,0,2,all,2km ≥ cycling
+15-19,males,Scenario,all_0_2,0.34176629625899774,Walking,0,2,all,2km ≥ cycling
+15-19,males,Scenario,commuting_0_2,0.038893769287482734,Cycling,0,2,commuting,2km ≥ cycling
+15-19,males,Scenario,commuting_0_2,0.42537832647201856,Car,0,2,commuting,2km ≥ cycling
+15-19,males,Scenario,commuting_0_2,0.014442947613094524,Other,0,2,commuting,2km ≥ cycling
+15-19,males,Scenario,commuting_0_2,0.17951866036840639,Public transport,0,2,commuting,2km ≥ cycling
+15-19,males,Scenario,commuting_0_2,0.34176629625899774,Walking,0,2,commuting,2km ≥ cycling
+15-19,males,Scenario,all_0_5,0.16357016375941413,Cycling,0,5,all,5km ≥ cycling
+15-19,males,Scenario,all_0_5,0.3007019320000872,Car,0,5,all,5km ≥ cycling
+15-19,males,Scenario,all_0_5,0.014442947613094524,Other,0,5,all,5km ≥ cycling
+15-19,males,Scenario,all_0_5,0.17951866036840639,Public transport,0,5,all,5km ≥ cycling
+15-19,males,Scenario,all_0_5,0.34176629625899774,Walking,0,5,all,5km ≥ cycling
+15-19,males,Scenario,commuting_0_5,0.07981693734463041,Cycling,0,5,commuting,5km ≥ cycling
+15-19,males,Scenario,commuting_0_5,0.38445515841487093,Car,0,5,commuting,5km ≥ cycling
+15-19,males,Scenario,commuting_0_5,0.014442947613094524,Other,0,5,commuting,5km ≥ cycling
+15-19,males,Scenario,commuting_0_5,0.17951866036840639,Public transport,0,5,commuting,5km ≥ cycling
+15-19,males,Scenario,commuting_0_5,0.34176629625899774,Walking,0,5,commuting,5km ≥ cycling
+15-19,males,Scenario,all_1_0,0.024795358204530115,Cycling,1,0,all,1km ≥ walking
+15-19,males,Scenario,all_1_0,0.43503513812829897,Car,1,0,all,1km ≥ walking
+15-19,males,Scenario,all_1_0,0.014442947613094524,Other,1,0,all,1km ≥ walking
+15-19,males,Scenario,all_1_0,0.17951866036840639,Public transport,1,0,all,1km ≥ walking
+15-19,males,Scenario,all_1_0,0.34620789568566995,Walking,1,0,all,1km ≥ walking
+15-19,males,Scenario,commuting_1_0,0.024795358204530115,Cycling,1,0,commuting,1km ≥ walking
+15-19,males,Scenario,commuting_1_0,0.43821294255999094,Car,1,0,commuting,1km ≥ walking
+15-19,males,Scenario,commuting_1_0,0.014442947613094524,Other,1,0,commuting,1km ≥ walking
+15-19,males,Scenario,commuting_1_0,0.17951866036840639,Public transport,1,0,commuting,1km ≥ walking
+15-19,males,Scenario,commuting_1_0,0.343030091253978,Walking,1,0,commuting,1km ≥ walking
+15-19,males,Scenario,all_1_2,0.05601944473407134,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Scenario,all_1_2,0.40381105159875774,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Scenario,all_1_2,0.014442947613094524,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Scenario,all_1_2,0.17951866036840639,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Scenario,all_1_2,0.34620789568566995,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Scenario,commuting_1_2,0.03762997429250247,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Scenario,commuting_1_2,0.42537832647201856,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Scenario,commuting_1_2,0.014442947613094524,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Scenario,commuting_1_2,0.17951866036840639,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Scenario,commuting_1_2,0.343030091253978,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,males,Scenario,all_1_5,0.1591285643327419,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Scenario,all_1_5,0.3007019320000872,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Scenario,all_1_5,0.014442947613094524,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Scenario,all_1_5,0.17951866036840639,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Scenario,all_1_5,0.34620789568566995,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Scenario,commuting_1_5,0.07855314234965015,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Scenario,commuting_1_5,0.38445515841487093,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Scenario,commuting_1_5,0.014442947613094524,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Scenario,commuting_1_5,0.17951866036840639,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Scenario,commuting_1_5,0.343030091253978,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,males,Scenario,all_2_0,0.024795358204530115,Cycling,2,0,all,2km ≥ walking
+15-19,males,Scenario,all_2_0,0.40381105159875774,Car,2,0,all,2km ≥ walking
+15-19,males,Scenario,all_2_0,0.014442947613094524,Other,2,0,all,2km ≥ walking
+15-19,males,Scenario,all_2_0,0.17951866036840639,Public transport,2,0,all,2km ≥ walking
+15-19,males,Scenario,all_2_0,0.3774319822152112,Walking,2,0,all,2km ≥ walking
+15-19,males,Scenario,commuting_2_0,0.024795358204530115,Cycling,2,0,commuting,2km ≥ walking
+15-19,males,Scenario,commuting_2_0,0.42537832647201856,Car,2,0,commuting,2km ≥ walking
+15-19,males,Scenario,commuting_2_0,0.014442947613094524,Other,2,0,commuting,2km ≥ walking
+15-19,males,Scenario,commuting_2_0,0.17951866036840639,Public transport,2,0,commuting,2km ≥ walking
+15-19,males,Scenario,commuting_2_0,0.35586470734195036,Walking,2,0,commuting,2km ≥ walking
+15-19,males,Scenario,all_2_5,0.12790447780320066,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Scenario,all_2_5,0.3007019320000872,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Scenario,all_2_5,0.014442947613094524,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Scenario,all_2_5,0.17951866036840639,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Scenario,all_2_5,0.3774319822152112,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Scenario,commuting_2_5,0.06571852626167779,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Scenario,commuting_2_5,0.38445515841487093,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Scenario,commuting_2_5,0.014442947613094524,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Scenario,commuting_2_5,0.17951866036840639,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,males,Scenario,commuting_2_5,0.35586470734195036,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Base case,all_0_2,0.001012557691556671,Cycling,0,2,all,2km ≥ cycling
+15-19,females,Base case,all_0_2,0.45512981394252416,Car,0,2,all,2km ≥ cycling
+15-19,females,Base case,all_0_2,0.006536549239146647,Other,0,2,all,2km ≥ cycling
+15-19,females,Base case,all_0_2,0.1967121047225559,Public transport,0,2,all,2km ≥ cycling
+15-19,females,Base case,all_0_2,0.3406089744042166,Walking,0,2,all,2km ≥ cycling
+15-19,females,Base case,commuting_0_2,0.001012557691556671,Cycling,0,2,commuting,2km ≥ cycling
+15-19,females,Base case,commuting_0_2,0.45512981394252416,Car,0,2,commuting,2km ≥ cycling
+15-19,females,Base case,commuting_0_2,0.006536549239146647,Other,0,2,commuting,2km ≥ cycling
+15-19,females,Base case,commuting_0_2,0.1967121047225559,Public transport,0,2,commuting,2km ≥ cycling
+15-19,females,Base case,commuting_0_2,0.3406089744042166,Walking,0,2,commuting,2km ≥ cycling
+15-19,females,Base case,all_0_5,0.001012557691556671,Cycling,0,5,all,5km ≥ cycling
+15-19,females,Base case,all_0_5,0.45512981394252416,Car,0,5,all,5km ≥ cycling
+15-19,females,Base case,all_0_5,0.006536549239146647,Other,0,5,all,5km ≥ cycling
+15-19,females,Base case,all_0_5,0.1967121047225559,Public transport,0,5,all,5km ≥ cycling
+15-19,females,Base case,all_0_5,0.3406089744042166,Walking,0,5,all,5km ≥ cycling
+15-19,females,Base case,commuting_0_5,0.001012557691556671,Cycling,0,5,commuting,5km ≥ cycling
+15-19,females,Base case,commuting_0_5,0.45512981394252416,Car,0,5,commuting,5km ≥ cycling
+15-19,females,Base case,commuting_0_5,0.006536549239146647,Other,0,5,commuting,5km ≥ cycling
+15-19,females,Base case,commuting_0_5,0.1967121047225559,Public transport,0,5,commuting,5km ≥ cycling
+15-19,females,Base case,commuting_0_5,0.3406089744042166,Walking,0,5,commuting,5km ≥ cycling
+15-19,females,Base case,all_1_0,0.001012557691556671,Cycling,1,0,all,1km ≥ walking
+15-19,females,Base case,all_1_0,0.45512981394252416,Car,1,0,all,1km ≥ walking
+15-19,females,Base case,all_1_0,0.006536549239146647,Other,1,0,all,1km ≥ walking
+15-19,females,Base case,all_1_0,0.1967121047225559,Public transport,1,0,all,1km ≥ walking
+15-19,females,Base case,all_1_0,0.3406089744042166,Walking,1,0,all,1km ≥ walking
+15-19,females,Base case,commuting_1_0,0.001012557691556671,Cycling,1,0,commuting,1km ≥ walking
+15-19,females,Base case,commuting_1_0,0.45512981394252416,Car,1,0,commuting,1km ≥ walking
+15-19,females,Base case,commuting_1_0,0.006536549239146647,Other,1,0,commuting,1km ≥ walking
+15-19,females,Base case,commuting_1_0,0.1967121047225559,Public transport,1,0,commuting,1km ≥ walking
+15-19,females,Base case,commuting_1_0,0.3406089744042166,Walking,1,0,commuting,1km ≥ walking
+15-19,females,Base case,all_1_2,0.001012557691556671,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Base case,all_1_2,0.45512981394252416,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Base case,all_1_2,0.006536549239146647,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Base case,all_1_2,0.1967121047225559,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Base case,all_1_2,0.3406089744042166,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Base case,commuting_1_2,0.001012557691556671,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Base case,commuting_1_2,0.45512981394252416,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Base case,commuting_1_2,0.006536549239146647,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Base case,commuting_1_2,0.1967121047225559,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Base case,commuting_1_2,0.3406089744042166,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Base case,all_1_5,0.001012557691556671,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Base case,all_1_5,0.45512981394252416,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Base case,all_1_5,0.006536549239146647,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Base case,all_1_5,0.1967121047225559,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Base case,all_1_5,0.3406089744042166,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Base case,commuting_1_5,0.001012557691556671,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Base case,commuting_1_5,0.45512981394252416,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Base case,commuting_1_5,0.006536549239146647,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Base case,commuting_1_5,0.1967121047225559,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Base case,commuting_1_5,0.3406089744042166,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Base case,all_2_0,0.001012557691556671,Cycling,2,0,all,2km ≥ walking
+15-19,females,Base case,all_2_0,0.45512981394252416,Car,2,0,all,2km ≥ walking
+15-19,females,Base case,all_2_0,0.006536549239146647,Other,2,0,all,2km ≥ walking
+15-19,females,Base case,all_2_0,0.1967121047225559,Public transport,2,0,all,2km ≥ walking
+15-19,females,Base case,all_2_0,0.3406089744042166,Walking,2,0,all,2km ≥ walking
+15-19,females,Base case,commuting_2_0,0.001012557691556671,Cycling,2,0,commuting,2km ≥ walking
+15-19,females,Base case,commuting_2_0,0.45512981394252416,Car,2,0,commuting,2km ≥ walking
+15-19,females,Base case,commuting_2_0,0.006536549239146647,Other,2,0,commuting,2km ≥ walking
+15-19,females,Base case,commuting_2_0,0.1967121047225559,Public transport,2,0,commuting,2km ≥ walking
+15-19,females,Base case,commuting_2_0,0.3406089744042166,Walking,2,0,commuting,2km ≥ walking
+15-19,females,Base case,all_2_5,0.001012557691556671,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Base case,all_2_5,0.45512981394252416,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Base case,all_2_5,0.006536549239146647,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Base case,all_2_5,0.1967121047225559,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Base case,all_2_5,0.3406089744042166,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Base case,commuting_2_5,0.001012557691556671,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Base case,commuting_2_5,0.45512981394252416,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Base case,commuting_2_5,0.006536549239146647,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Base case,commuting_2_5,0.1967121047225559,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Base case,commuting_2_5,0.3406089744042166,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Scenario,all_0_2,0.053099899261802155,Cycling,0,2,all,2km ≥ cycling
+15-19,females,Scenario,all_0_2,0.4030424723722787,Car,0,2,all,2km ≥ cycling
+15-19,females,Scenario,all_0_2,0.006536549239146647,Other,0,2,all,2km ≥ cycling
+15-19,females,Scenario,all_0_2,0.1967121047225559,Public transport,0,2,all,2km ≥ cycling
+15-19,females,Scenario,all_0_2,0.3406089744042166,Walking,0,2,all,2km ≥ cycling
+15-19,females,Scenario,commuting_0_2,0.00777335646406573,Cycling,0,2,commuting,2km ≥ cycling
+15-19,females,Scenario,commuting_0_2,0.4483690151700151,Car,0,2,commuting,2km ≥ cycling
+15-19,females,Scenario,commuting_0_2,0.006536549239146647,Other,0,2,commuting,2km ≥ cycling
+15-19,females,Scenario,commuting_0_2,0.1967121047225559,Public transport,0,2,commuting,2km ≥ cycling
+15-19,females,Scenario,commuting_0_2,0.3406089744042166,Walking,0,2,commuting,2km ≥ cycling
+15-19,females,Scenario,all_0_5,0.16056050149836895,Cycling,0,5,all,5km ≥ cycling
+15-19,females,Scenario,all_0_5,0.2955818701357119,Car,0,5,all,5km ≥ cycling
+15-19,females,Scenario,all_0_5,0.006536549239146647,Other,0,5,all,5km ≥ cycling
+15-19,females,Scenario,all_0_5,0.1967121047225559,Public transport,0,5,all,5km ≥ cycling
+15-19,females,Scenario,all_0_5,0.3406089744042166,Walking,0,5,all,5km ≥ cycling
+15-19,females,Scenario,commuting_0_5,0.04308498850285911,Cycling,0,5,commuting,5km ≥ cycling
+15-19,females,Scenario,commuting_0_5,0.4130573831312217,Car,0,5,commuting,5km ≥ cycling
+15-19,females,Scenario,commuting_0_5,0.006536549239146647,Other,0,5,commuting,5km ≥ cycling
+15-19,females,Scenario,commuting_0_5,0.1967121047225559,Public transport,0,5,commuting,5km ≥ cycling
+15-19,females,Scenario,commuting_0_5,0.3406089744042166,Walking,0,5,commuting,5km ≥ cycling
+15-19,females,Scenario,all_1_0,0.001012557691556671,Cycling,1,0,all,1km ≥ walking
+15-19,females,Scenario,all_1_0,0.4403042190060655,Car,1,0,all,1km ≥ walking
+15-19,females,Scenario,all_1_0,0.006536549239146647,Other,1,0,all,1km ≥ walking
+15-19,females,Scenario,all_1_0,0.1967121047225559,Public transport,1,0,all,1km ≥ walking
+15-19,females,Scenario,all_1_0,0.3554345693406753,Walking,1,0,all,1km ≥ walking
+15-19,females,Scenario,commuting_1_0,0.001012557691556671,Cycling,1,0,commuting,1km ≥ walking
+15-19,females,Scenario,commuting_1_0,0.4535693834925806,Car,1,0,commuting,1km ≥ walking
+15-19,females,Scenario,commuting_1_0,0.006536549239146647,Other,1,0,commuting,1km ≥ walking
+15-19,females,Scenario,commuting_1_0,0.1967121047225559,Public transport,1,0,commuting,1km ≥ walking
+15-19,females,Scenario,commuting_1_0,0.34216940485416014,Walking,1,0,commuting,1km ≥ walking
+15-19,females,Scenario,all_1_2,0.03827430432534344,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Scenario,all_1_2,0.4030424723722787,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Scenario,all_1_2,0.006536549239146647,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Scenario,all_1_2,0.1967121047225559,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Scenario,all_1_2,0.3554345693406753,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Scenario,commuting_1_2,0.006212926014122168,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Scenario,commuting_1_2,0.4483690151700151,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Scenario,commuting_1_2,0.006536549239146647,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Scenario,commuting_1_2,0.1967121047225559,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Scenario,commuting_1_2,0.34216940485416014,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females,Scenario,all_1_5,0.14573490656191024,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Scenario,all_1_5,0.2955818701357119,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Scenario,all_1_5,0.006536549239146647,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Scenario,all_1_5,0.1967121047225559,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Scenario,all_1_5,0.3554345693406753,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Scenario,commuting_1_5,0.04152455805291555,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Scenario,commuting_1_5,0.4130573831312217,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Scenario,commuting_1_5,0.006536549239146647,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Scenario,commuting_1_5,0.1967121047225559,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Scenario,commuting_1_5,0.34216940485416014,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females,Scenario,all_2_0,0.001012557691556671,Cycling,2,0,all,2km ≥ walking
+15-19,females,Scenario,all_2_0,0.4030424723722787,Car,2,0,all,2km ≥ walking
+15-19,females,Scenario,all_2_0,0.006536549239146647,Other,2,0,all,2km ≥ walking
+15-19,females,Scenario,all_2_0,0.1967121047225559,Public transport,2,0,all,2km ≥ walking
+15-19,females,Scenario,all_2_0,0.3926963159744621,Walking,2,0,all,2km ≥ walking
+15-19,females,Scenario,commuting_2_0,0.001012557691556671,Cycling,2,0,commuting,2km ≥ walking
+15-19,females,Scenario,commuting_2_0,0.4483690151700151,Car,2,0,commuting,2km ≥ walking
+15-19,females,Scenario,commuting_2_0,0.006536549239146647,Other,2,0,commuting,2km ≥ walking
+15-19,females,Scenario,commuting_2_0,0.1967121047225559,Public transport,2,0,commuting,2km ≥ walking
+15-19,females,Scenario,commuting_2_0,0.3473697731767257,Walking,2,0,commuting,2km ≥ walking
+15-19,females,Scenario,all_2_5,0.10847315992812347,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Scenario,all_2_5,0.2955818701357119,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Scenario,all_2_5,0.006536549239146647,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Scenario,all_2_5,0.1967121047225559,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Scenario,all_2_5,0.3926963159744621,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Scenario,commuting_2_5,0.03632418973035005,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Scenario,commuting_2_5,0.4130573831312217,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Scenario,commuting_2_5,0.006536549239146647,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Scenario,commuting_2_5,0.1967121047225559,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females,Scenario,commuting_2_5,0.3473697731767257,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Base case,all_0_2,0.010244720664109383,Cycling,0,2,all,2km ≥ cycling
+15-19,females and males,Base case,all_0_2,0.4490535004254144,Car,0,2,all,2km ≥ cycling
+15-19,females and males,Base case,all_0_2,0.00960570664449069,Other,0,2,all,2km ≥ cycling
+15-19,females and males,Base case,all_0_2,0.19003784109870572,Public transport,0,2,all,2km ≥ cycling
+15-19,females and males,Base case,all_0_2,0.34105823116727985,Walking,0,2,all,2km ≥ cycling
+15-19,females and males,Base case,commuting_0_2,0.010244720664109383,Cycling,0,2,commuting,2km ≥ cycling
+15-19,females and males,Base case,commuting_0_2,0.4490535004254144,Car,0,2,commuting,2km ≥ cycling
+15-19,females and males,Base case,commuting_0_2,0.00960570664449069,Other,0,2,commuting,2km ≥ cycling
+15-19,females and males,Base case,commuting_0_2,0.19003784109870572,Public transport,0,2,commuting,2km ≥ cycling
+15-19,females and males,Base case,commuting_0_2,0.34105823116727985,Walking,0,2,commuting,2km ≥ cycling
+15-19,females and males,Base case,all_0_5,0.010244720664109383,Cycling,0,5,all,5km ≥ cycling
+15-19,females and males,Base case,all_0_5,0.4490535004254144,Car,0,5,all,5km ≥ cycling
+15-19,females and males,Base case,all_0_5,0.00960570664449069,Other,0,5,all,5km ≥ cycling
+15-19,females and males,Base case,all_0_5,0.19003784109870572,Public transport,0,5,all,5km ≥ cycling
+15-19,females and males,Base case,all_0_5,0.34105823116727985,Walking,0,5,all,5km ≥ cycling
+15-19,females and males,Base case,commuting_0_5,0.010244720664109383,Cycling,0,5,commuting,5km ≥ cycling
+15-19,females and males,Base case,commuting_0_5,0.4490535004254144,Car,0,5,commuting,5km ≥ cycling
+15-19,females and males,Base case,commuting_0_5,0.00960570664449069,Other,0,5,commuting,5km ≥ cycling
+15-19,females and males,Base case,commuting_0_5,0.19003784109870572,Public transport,0,5,commuting,5km ≥ cycling
+15-19,females and males,Base case,commuting_0_5,0.34105823116727985,Walking,0,5,commuting,5km ≥ cycling
+15-19,females and males,Base case,all_1_0,0.010244720664109383,Cycling,1,0,all,1km ≥ walking
+15-19,females and males,Base case,all_1_0,0.4490535004254144,Car,1,0,all,1km ≥ walking
+15-19,females and males,Base case,all_1_0,0.00960570664449069,Other,1,0,all,1km ≥ walking
+15-19,females and males,Base case,all_1_0,0.19003784109870572,Public transport,1,0,all,1km ≥ walking
+15-19,females and males,Base case,all_1_0,0.34105823116727985,Walking,1,0,all,1km ≥ walking
+15-19,females and males,Base case,commuting_1_0,0.010244720664109383,Cycling,1,0,commuting,1km ≥ walking
+15-19,females and males,Base case,commuting_1_0,0.4490535004254144,Car,1,0,commuting,1km ≥ walking
+15-19,females and males,Base case,commuting_1_0,0.00960570664449069,Other,1,0,commuting,1km ≥ walking
+15-19,females and males,Base case,commuting_1_0,0.19003784109870572,Public transport,1,0,commuting,1km ≥ walking
+15-19,females and males,Base case,commuting_1_0,0.34105823116727985,Walking,1,0,commuting,1km ≥ walking
+15-19,females and males,Base case,all_1_2,0.010244720664109383,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Base case,all_1_2,0.4490535004254144,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Base case,all_1_2,0.00960570664449069,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Base case,all_1_2,0.19003784109870572,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Base case,all_1_2,0.34105823116727985,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Base case,commuting_1_2,0.010244720664109383,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Base case,commuting_1_2,0.4490535004254144,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Base case,commuting_1_2,0.00960570664449069,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Base case,commuting_1_2,0.19003784109870572,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Base case,commuting_1_2,0.34105823116727985,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Base case,all_1_5,0.010244720664109383,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Base case,all_1_5,0.4490535004254144,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Base case,all_1_5,0.00960570664449069,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Base case,all_1_5,0.19003784109870572,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Base case,all_1_5,0.34105823116727985,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Base case,commuting_1_5,0.010244720664109383,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Base case,commuting_1_5,0.4490535004254144,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Base case,commuting_1_5,0.00960570664449069,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Base case,commuting_1_5,0.19003784109870572,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Base case,commuting_1_5,0.34105823116727985,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Base case,all_2_0,0.010244720664109383,Cycling,2,0,all,2km ≥ walking
+15-19,females and males,Base case,all_2_0,0.4490535004254144,Car,2,0,all,2km ≥ walking
+15-19,females and males,Base case,all_2_0,0.00960570664449069,Other,2,0,all,2km ≥ walking
+15-19,females and males,Base case,all_2_0,0.19003784109870572,Public transport,2,0,all,2km ≥ walking
+15-19,females and males,Base case,all_2_0,0.34105823116727985,Walking,2,0,all,2km ≥ walking
+15-19,females and males,Base case,commuting_2_0,0.010244720664109383,Cycling,2,0,commuting,2km ≥ walking
+15-19,females and males,Base case,commuting_2_0,0.4490535004254144,Car,2,0,commuting,2km ≥ walking
+15-19,females and males,Base case,commuting_2_0,0.00960570664449069,Other,2,0,commuting,2km ≥ walking
+15-19,females and males,Base case,commuting_2_0,0.19003784109870572,Public transport,2,0,commuting,2km ≥ walking
+15-19,females and males,Base case,commuting_2_0,0.34105823116727985,Walking,2,0,commuting,2km ≥ walking
+15-19,females and males,Base case,all_2_5,0.010244720664109383,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Base case,all_2_5,0.4490535004254144,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Base case,all_2_5,0.00960570664449069,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Base case,all_2_5,0.19003784109870572,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Base case,all_2_5,0.34105823116727985,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Base case,commuting_2_5,0.010244720664109383,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Base case,commuting_2_5,0.4490535004254144,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Base case,commuting_2_5,0.00960570664449069,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Base case,commuting_2_5,0.19003784109870572,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Base case,commuting_2_5,0.34105823116727985,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Scenario,all_0_2,0.055957396608867345,Cycling,0,2,all,2km ≥ cycling
+15-19,females and males,Scenario,all_0_2,0.40334082448065645,Car,0,2,all,2km ≥ cycling
+15-19,females and males,Scenario,all_0_2,0.00960570664449069,Other,0,2,all,2km ≥ cycling
+15-19,females and males,Scenario,all_0_2,0.19003784109870572,Public transport,0,2,all,2km ≥ cycling
+15-19,females and males,Scenario,all_0_2,0.34105823116727985,Walking,0,2,all,2km ≥ cycling
+15-19,females and males,Scenario,commuting_0_2,0.019853881749646755,Cycling,0,2,commuting,2km ≥ cycling
+15-19,females and males,Scenario,commuting_0_2,0.43944433933987703,Car,0,2,commuting,2km ≥ cycling
+15-19,females and males,Scenario,commuting_0_2,0.00960570664449069,Other,0,2,commuting,2km ≥ cycling
+15-19,females and males,Scenario,commuting_0_2,0.19003784109870572,Public transport,0,2,commuting,2km ≥ cycling
+15-19,females and males,Scenario,commuting_0_2,0.34105823116727985,Walking,0,2,commuting,2km ≥ cycling
+15-19,females and males,Scenario,all_0_5,0.1617288118691831,Cycling,0,5,all,5km ≥ cycling
+15-19,females and males,Scenario,all_0_5,0.29756940922034075,Car,0,5,all,5km ≥ cycling
+15-19,females and males,Scenario,all_0_5,0.00960570664449069,Other,0,5,all,5km ≥ cycling
+15-19,females and males,Scenario,all_0_5,0.19003784109870572,Public transport,0,5,all,5km ≥ cycling
+15-19,females and males,Scenario,all_0_5,0.34105823116727985,Walking,0,5,all,5km ≥ cycling
+15-19,females and males,Scenario,commuting_0_5,0.05734383652295309,Cycling,0,5,commuting,5km ≥ cycling
+15-19,females and males,Scenario,commuting_0_5,0.40195438456657073,Car,0,5,commuting,5km ≥ cycling
+15-19,females and males,Scenario,commuting_0_5,0.00960570664449069,Other,0,5,commuting,5km ≥ cycling
+15-19,females and males,Scenario,commuting_0_5,0.19003784109870572,Public transport,0,5,commuting,5km ≥ cycling
+15-19,females and males,Scenario,commuting_0_5,0.34105823116727985,Walking,0,5,commuting,5km ≥ cycling
+15-19,females and males,Scenario,all_1_0,0.010244720664109383,Cycling,1,0,all,1km ≥ walking
+15-19,females and males,Scenario,all_1_0,0.4382588327466733,Car,1,0,all,1km ≥ walking
+15-19,females and males,Scenario,all_1_0,0.00960570664449069,Other,1,0,all,1km ≥ walking
+15-19,females and males,Scenario,all_1_0,0.19003784109870572,Public transport,1,0,all,1km ≥ walking
+15-19,females and males,Scenario,all_1_0,0.35185289884602095,Walking,1,0,all,1km ≥ walking
+15-19,females and males,Scenario,commuting_1_0,0.010244720664109383,Cycling,1,0,commuting,1km ≥ walking
+15-19,females and males,Scenario,commuting_1_0,0.4476082198655002,Car,1,0,commuting,1km ≥ walking
+15-19,females and males,Scenario,commuting_1_0,0.00960570664449069,Other,1,0,commuting,1km ≥ walking
+15-19,females and males,Scenario,commuting_1_0,0.19003784109870572,Public transport,1,0,commuting,1km ≥ walking
+15-19,females and males,Scenario,commuting_1_0,0.34250351172719407,Walking,1,0,commuting,1km ≥ walking
+15-19,females and males,Scenario,all_1_2,0.04516272893012622,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Scenario,all_1_2,0.40334082448065645,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Scenario,all_1_2,0.00960570664449069,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Scenario,all_1_2,0.19003784109870572,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Scenario,all_1_2,0.35185289884602095,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Scenario,commuting_1_2,0.01840860118973253,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Scenario,commuting_1_2,0.43944433933987703,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Scenario,commuting_1_2,0.00960570664449069,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Scenario,commuting_1_2,0.19003784109870572,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Scenario,commuting_1_2,0.34250351172719407,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+15-19,females and males,Scenario,all_1_5,0.15093414419044196,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Scenario,all_1_5,0.29756940922034075,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Scenario,all_1_5,0.00960570664449069,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Scenario,all_1_5,0.19003784109870572,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Scenario,all_1_5,0.35185289884602095,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Scenario,commuting_1_5,0.055898555963038866,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Scenario,commuting_1_5,0.40195438456657073,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Scenario,commuting_1_5,0.00960570664449069,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Scenario,commuting_1_5,0.19003784109870572,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Scenario,commuting_1_5,0.34250351172719407,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+15-19,females and males,Scenario,all_2_0,0.010244720664109383,Cycling,2,0,all,2km ≥ walking
+15-19,females and males,Scenario,all_2_0,0.40334082448065645,Car,2,0,all,2km ≥ walking
+15-19,females and males,Scenario,all_2_0,0.00960570664449069,Other,2,0,all,2km ≥ walking
+15-19,females and males,Scenario,all_2_0,0.19003784109870572,Public transport,2,0,all,2km ≥ walking
+15-19,females and males,Scenario,all_2_0,0.38677090711203777,Walking,2,0,all,2km ≥ walking
+15-19,females and males,Scenario,commuting_2_0,0.010244720664109383,Cycling,2,0,commuting,2km ≥ walking
+15-19,females and males,Scenario,commuting_2_0,0.43944433933987703,Car,2,0,commuting,2km ≥ walking
+15-19,females and males,Scenario,commuting_2_0,0.00960570664449069,Other,2,0,commuting,2km ≥ walking
+15-19,females and males,Scenario,commuting_2_0,0.19003784109870572,Public transport,2,0,commuting,2km ≥ walking
+15-19,females and males,Scenario,commuting_2_0,0.3506673922528172,Walking,2,0,commuting,2km ≥ walking
+15-19,females and males,Scenario,all_2_5,0.11601613592442513,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Scenario,all_2_5,0.29756940922034075,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Scenario,all_2_5,0.00960570664449069,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Scenario,all_2_5,0.19003784109870572,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Scenario,all_2_5,0.38677090711203777,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Scenario,commuting_2_5,0.04773467543741572,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Scenario,commuting_2_5,0.40195438456657073,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Scenario,commuting_2_5,0.00960570664449069,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Scenario,commuting_2_5,0.19003784109870572,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+15-19,females and males,Scenario,commuting_2_5,0.3506673922528172,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Base case,all_0_2,0.016945253557700612,Cycling,0,2,all,2km ≥ cycling
+20-39,males,Base case,all_0_2,0.5965913117640641,Car,0,2,all,2km ≥ cycling
+20-39,males,Base case,all_0_2,0.009873231377571786,Other,0,2,all,2km ≥ cycling
+20-39,males,Base case,all_0_2,0.11183595827752565,Public transport,0,2,all,2km ≥ cycling
+20-39,males,Base case,all_0_2,0.2647542450231378,Walking,0,2,all,2km ≥ cycling
+20-39,males,Base case,commuting_0_2,0.016945253557700612,Cycling,0,2,commuting,2km ≥ cycling
+20-39,males,Base case,commuting_0_2,0.5965913117640641,Car,0,2,commuting,2km ≥ cycling
+20-39,males,Base case,commuting_0_2,0.009873231377571786,Other,0,2,commuting,2km ≥ cycling
+20-39,males,Base case,commuting_0_2,0.11183595827752565,Public transport,0,2,commuting,2km ≥ cycling
+20-39,males,Base case,commuting_0_2,0.2647542450231378,Walking,0,2,commuting,2km ≥ cycling
+20-39,males,Base case,all_0_5,0.016945253557700612,Cycling,0,5,all,5km ≥ cycling
+20-39,males,Base case,all_0_5,0.5965913117640641,Car,0,5,all,5km ≥ cycling
+20-39,males,Base case,all_0_5,0.009873231377571786,Other,0,5,all,5km ≥ cycling
+20-39,males,Base case,all_0_5,0.11183595827752565,Public transport,0,5,all,5km ≥ cycling
+20-39,males,Base case,all_0_5,0.2647542450231378,Walking,0,5,all,5km ≥ cycling
+20-39,males,Base case,commuting_0_5,0.016945253557700612,Cycling,0,5,commuting,5km ≥ cycling
+20-39,males,Base case,commuting_0_5,0.5965913117640641,Car,0,5,commuting,5km ≥ cycling
+20-39,males,Base case,commuting_0_5,0.009873231377571786,Other,0,5,commuting,5km ≥ cycling
+20-39,males,Base case,commuting_0_5,0.11183595827752565,Public transport,0,5,commuting,5km ≥ cycling
+20-39,males,Base case,commuting_0_5,0.2647542450231378,Walking,0,5,commuting,5km ≥ cycling
+20-39,males,Base case,all_1_0,0.016945253557700612,Cycling,1,0,all,1km ≥ walking
+20-39,males,Base case,all_1_0,0.5965913117640641,Car,1,0,all,1km ≥ walking
+20-39,males,Base case,all_1_0,0.009873231377571786,Other,1,0,all,1km ≥ walking
+20-39,males,Base case,all_1_0,0.11183595827752565,Public transport,1,0,all,1km ≥ walking
+20-39,males,Base case,all_1_0,0.2647542450231378,Walking,1,0,all,1km ≥ walking
+20-39,males,Base case,commuting_1_0,0.016945253557700612,Cycling,1,0,commuting,1km ≥ walking
+20-39,males,Base case,commuting_1_0,0.5965913117640641,Car,1,0,commuting,1km ≥ walking
+20-39,males,Base case,commuting_1_0,0.009873231377571786,Other,1,0,commuting,1km ≥ walking
+20-39,males,Base case,commuting_1_0,0.11183595827752565,Public transport,1,0,commuting,1km ≥ walking
+20-39,males,Base case,commuting_1_0,0.2647542450231378,Walking,1,0,commuting,1km ≥ walking
+20-39,males,Base case,all_1_2,0.016945253557700612,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Base case,all_1_2,0.5965913117640641,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Base case,all_1_2,0.009873231377571786,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Base case,all_1_2,0.11183595827752565,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Base case,all_1_2,0.2647542450231378,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Base case,commuting_1_2,0.016945253557700612,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Base case,commuting_1_2,0.5965913117640641,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Base case,commuting_1_2,0.009873231377571786,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Base case,commuting_1_2,0.11183595827752565,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Base case,commuting_1_2,0.2647542450231378,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Base case,all_1_5,0.016945253557700612,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Base case,all_1_5,0.5965913117640641,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Base case,all_1_5,0.009873231377571786,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Base case,all_1_5,0.11183595827752565,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Base case,all_1_5,0.2647542450231378,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Base case,commuting_1_5,0.016945253557700612,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Base case,commuting_1_5,0.5965913117640641,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Base case,commuting_1_5,0.009873231377571786,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Base case,commuting_1_5,0.11183595827752565,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Base case,commuting_1_5,0.2647542450231378,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Base case,all_2_0,0.016945253557700612,Cycling,2,0,all,2km ≥ walking
+20-39,males,Base case,all_2_0,0.5965913117640641,Car,2,0,all,2km ≥ walking
+20-39,males,Base case,all_2_0,0.009873231377571786,Other,2,0,all,2km ≥ walking
+20-39,males,Base case,all_2_0,0.11183595827752565,Public transport,2,0,all,2km ≥ walking
+20-39,males,Base case,all_2_0,0.2647542450231378,Walking,2,0,all,2km ≥ walking
+20-39,males,Base case,commuting_2_0,0.016945253557700612,Cycling,2,0,commuting,2km ≥ walking
+20-39,males,Base case,commuting_2_0,0.5965913117640641,Car,2,0,commuting,2km ≥ walking
+20-39,males,Base case,commuting_2_0,0.009873231377571786,Other,2,0,commuting,2km ≥ walking
+20-39,males,Base case,commuting_2_0,0.11183595827752565,Public transport,2,0,commuting,2km ≥ walking
+20-39,males,Base case,commuting_2_0,0.2647542450231378,Walking,2,0,commuting,2km ≥ walking
+20-39,males,Base case,all_2_5,0.016945253557700612,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Base case,all_2_5,0.5965913117640641,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Base case,all_2_5,0.009873231377571786,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Base case,all_2_5,0.11183595827752565,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Base case,all_2_5,0.2647542450231378,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Base case,commuting_2_5,0.016945253557700612,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Base case,commuting_2_5,0.5965913117640641,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Base case,commuting_2_5,0.009873231377571786,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Base case,commuting_2_5,0.11183595827752565,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Base case,commuting_2_5,0.2647542450231378,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Scenario,all_0_2,0.0996435580178128,Cycling,0,2,all,2km ≥ cycling
+20-39,males,Scenario,all_0_2,0.5138930073039519,Car,0,2,all,2km ≥ cycling
+20-39,males,Scenario,all_0_2,0.009873231377571786,Other,0,2,all,2km ≥ cycling
+20-39,males,Scenario,all_0_2,0.11183595827752565,Public transport,0,2,all,2km ≥ cycling
+20-39,males,Scenario,all_0_2,0.2647542450231378,Walking,0,2,all,2km ≥ cycling
+20-39,males,Scenario,commuting_0_2,0.030838013191081388,Cycling,0,2,commuting,2km ≥ cycling
+20-39,males,Scenario,commuting_0_2,0.5826985521306833,Car,0,2,commuting,2km ≥ cycling
+20-39,males,Scenario,commuting_0_2,0.009873231377571786,Other,0,2,commuting,2km ≥ cycling
+20-39,males,Scenario,commuting_0_2,0.11183595827752565,Public transport,0,2,commuting,2km ≥ cycling
+20-39,males,Scenario,commuting_0_2,0.2647542450231378,Walking,0,2,commuting,2km ≥ cycling
+20-39,males,Scenario,all_0_5,0.2276220053211013,Cycling,0,5,all,5km ≥ cycling
+20-39,males,Scenario,all_0_5,0.3859145600006634,Car,0,5,all,5km ≥ cycling
+20-39,males,Scenario,all_0_5,0.009873231377571786,Other,0,5,all,5km ≥ cycling
+20-39,males,Scenario,all_0_5,0.11183595827752565,Public transport,0,5,all,5km ≥ cycling
+20-39,males,Scenario,all_0_5,0.2647542450231378,Walking,0,5,all,5km ≥ cycling
+20-39,males,Scenario,commuting_0_5,0.058954658838466484,Cycling,0,5,commuting,5km ≥ cycling
+20-39,males,Scenario,commuting_0_5,0.5545819064832982,Car,0,5,commuting,5km ≥ cycling
+20-39,males,Scenario,commuting_0_5,0.009873231377571786,Other,0,5,commuting,5km ≥ cycling
+20-39,males,Scenario,commuting_0_5,0.11183595827752565,Public transport,0,5,commuting,5km ≥ cycling
+20-39,males,Scenario,commuting_0_5,0.2647542450231378,Walking,0,5,commuting,5km ≥ cycling
+20-39,males,Scenario,all_1_0,0.016945253557700612,Cycling,1,0,all,1km ≥ walking
+20-39,males,Scenario,all_1_0,0.5718354823831097,Car,1,0,all,1km ≥ walking
+20-39,males,Scenario,all_1_0,0.009873231377571786,Other,1,0,all,1km ≥ walking
+20-39,males,Scenario,all_1_0,0.11183595827752565,Public transport,1,0,all,1km ≥ walking
+20-39,males,Scenario,all_1_0,0.2895100744040922,Walking,1,0,all,1km ≥ walking
+20-39,males,Scenario,commuting_1_0,0.016945253557700612,Cycling,1,0,commuting,1km ≥ walking
+20-39,males,Scenario,commuting_1_0,0.5920183223386252,Car,1,0,commuting,1km ≥ walking
+20-39,males,Scenario,commuting_1_0,0.009873231377571786,Other,1,0,commuting,1km ≥ walking
+20-39,males,Scenario,commuting_1_0,0.11183595827752565,Public transport,1,0,commuting,1km ≥ walking
+20-39,males,Scenario,commuting_1_0,0.2693272344485768,Walking,1,0,commuting,1km ≥ walking
+20-39,males,Scenario,all_1_2,0.07488772863685841,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Scenario,all_1_2,0.5138930073039519,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Scenario,all_1_2,0.009873231377571786,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Scenario,all_1_2,0.11183595827752565,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Scenario,all_1_2,0.2895100744040922,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Scenario,commuting_1_2,0.026265023765642437,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Scenario,commuting_1_2,0.5826985521306833,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Scenario,commuting_1_2,0.009873231377571786,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Scenario,commuting_1_2,0.11183595827752565,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Scenario,commuting_1_2,0.2693272344485768,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,males,Scenario,all_1_5,0.20286617594014694,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Scenario,all_1_5,0.3859145600006634,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Scenario,all_1_5,0.009873231377571786,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Scenario,all_1_5,0.11183595827752565,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Scenario,all_1_5,0.2895100744040922,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Scenario,commuting_1_5,0.054381669413027536,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Scenario,commuting_1_5,0.5545819064832982,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Scenario,commuting_1_5,0.009873231377571786,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Scenario,commuting_1_5,0.11183595827752565,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Scenario,commuting_1_5,0.2693272344485768,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,males,Scenario,all_2_0,0.016945253557700612,Cycling,2,0,all,2km ≥ walking
+20-39,males,Scenario,all_2_0,0.5138930073039519,Car,2,0,all,2km ≥ walking
+20-39,males,Scenario,all_2_0,0.009873231377571786,Other,2,0,all,2km ≥ walking
+20-39,males,Scenario,all_2_0,0.11183595827752565,Public transport,2,0,all,2km ≥ walking
+20-39,males,Scenario,all_2_0,0.34745254948325005,Walking,2,0,all,2km ≥ walking
+20-39,males,Scenario,commuting_2_0,0.016945253557700612,Cycling,2,0,commuting,2km ≥ walking
+20-39,males,Scenario,commuting_2_0,0.5826985521306833,Car,2,0,commuting,2km ≥ walking
+20-39,males,Scenario,commuting_2_0,0.009873231377571786,Other,2,0,commuting,2km ≥ walking
+20-39,males,Scenario,commuting_2_0,0.11183595827752565,Public transport,2,0,commuting,2km ≥ walking
+20-39,males,Scenario,commuting_2_0,0.2786470046565186,Walking,2,0,commuting,2km ≥ walking
+20-39,males,Scenario,all_2_5,0.14492370086098913,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Scenario,all_2_5,0.3859145600006634,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Scenario,all_2_5,0.009873231377571786,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Scenario,all_2_5,0.11183595827752565,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Scenario,all_2_5,0.34745254948325005,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Scenario,commuting_2_5,0.04506189920508571,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Scenario,commuting_2_5,0.5545819064832982,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Scenario,commuting_2_5,0.009873231377571786,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Scenario,commuting_2_5,0.11183595827752565,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,males,Scenario,commuting_2_5,0.2786470046565186,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Base case,all_0_2,0.011733417081580372,Cycling,0,2,all,2km ≥ cycling
+20-39,females,Base case,all_0_2,0.5652262788833393,Car,0,2,all,2km ≥ cycling
+20-39,females,Base case,all_0_2,0.005432591007426083,Other,0,2,all,2km ≥ cycling
+20-39,females,Base case,all_0_2,0.11250143927592476,Public transport,0,2,all,2km ≥ cycling
+20-39,females,Base case,all_0_2,0.30510627375172955,Walking,0,2,all,2km ≥ cycling
+20-39,females,Base case,commuting_0_2,0.011733417081580372,Cycling,0,2,commuting,2km ≥ cycling
+20-39,females,Base case,commuting_0_2,0.5652262788833393,Car,0,2,commuting,2km ≥ cycling
+20-39,females,Base case,commuting_0_2,0.005432591007426083,Other,0,2,commuting,2km ≥ cycling
+20-39,females,Base case,commuting_0_2,0.11250143927592476,Public transport,0,2,commuting,2km ≥ cycling
+20-39,females,Base case,commuting_0_2,0.30510627375172955,Walking,0,2,commuting,2km ≥ cycling
+20-39,females,Base case,all_0_5,0.011733417081580372,Cycling,0,5,all,5km ≥ cycling
+20-39,females,Base case,all_0_5,0.5652262788833393,Car,0,5,all,5km ≥ cycling
+20-39,females,Base case,all_0_5,0.005432591007426083,Other,0,5,all,5km ≥ cycling
+20-39,females,Base case,all_0_5,0.11250143927592476,Public transport,0,5,all,5km ≥ cycling
+20-39,females,Base case,all_0_5,0.30510627375172955,Walking,0,5,all,5km ≥ cycling
+20-39,females,Base case,commuting_0_5,0.011733417081580372,Cycling,0,5,commuting,5km ≥ cycling
+20-39,females,Base case,commuting_0_5,0.5652262788833393,Car,0,5,commuting,5km ≥ cycling
+20-39,females,Base case,commuting_0_5,0.005432591007426083,Other,0,5,commuting,5km ≥ cycling
+20-39,females,Base case,commuting_0_5,0.11250143927592476,Public transport,0,5,commuting,5km ≥ cycling
+20-39,females,Base case,commuting_0_5,0.30510627375172955,Walking,0,5,commuting,5km ≥ cycling
+20-39,females,Base case,all_1_0,0.011733417081580372,Cycling,1,0,all,1km ≥ walking
+20-39,females,Base case,all_1_0,0.5652262788833393,Car,1,0,all,1km ≥ walking
+20-39,females,Base case,all_1_0,0.005432591007426083,Other,1,0,all,1km ≥ walking
+20-39,females,Base case,all_1_0,0.11250143927592476,Public transport,1,0,all,1km ≥ walking
+20-39,females,Base case,all_1_0,0.30510627375172955,Walking,1,0,all,1km ≥ walking
+20-39,females,Base case,commuting_1_0,0.011733417081580372,Cycling,1,0,commuting,1km ≥ walking
+20-39,females,Base case,commuting_1_0,0.5652262788833393,Car,1,0,commuting,1km ≥ walking
+20-39,females,Base case,commuting_1_0,0.005432591007426083,Other,1,0,commuting,1km ≥ walking
+20-39,females,Base case,commuting_1_0,0.11250143927592476,Public transport,1,0,commuting,1km ≥ walking
+20-39,females,Base case,commuting_1_0,0.30510627375172955,Walking,1,0,commuting,1km ≥ walking
+20-39,females,Base case,all_1_2,0.011733417081580372,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Base case,all_1_2,0.5652262788833393,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Base case,all_1_2,0.005432591007426083,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Base case,all_1_2,0.11250143927592476,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Base case,all_1_2,0.30510627375172955,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Base case,commuting_1_2,0.011733417081580372,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Base case,commuting_1_2,0.5652262788833393,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Base case,commuting_1_2,0.005432591007426083,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Base case,commuting_1_2,0.11250143927592476,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Base case,commuting_1_2,0.30510627375172955,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Base case,all_1_5,0.011733417081580372,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Base case,all_1_5,0.5652262788833393,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Base case,all_1_5,0.005432591007426083,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Base case,all_1_5,0.11250143927592476,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Base case,all_1_5,0.30510627375172955,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Base case,commuting_1_5,0.011733417081580372,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Base case,commuting_1_5,0.5652262788833393,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Base case,commuting_1_5,0.005432591007426083,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Base case,commuting_1_5,0.11250143927592476,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Base case,commuting_1_5,0.30510627375172955,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Base case,all_2_0,0.011733417081580372,Cycling,2,0,all,2km ≥ walking
+20-39,females,Base case,all_2_0,0.5652262788833393,Car,2,0,all,2km ≥ walking
+20-39,females,Base case,all_2_0,0.005432591007426083,Other,2,0,all,2km ≥ walking
+20-39,females,Base case,all_2_0,0.11250143927592476,Public transport,2,0,all,2km ≥ walking
+20-39,females,Base case,all_2_0,0.30510627375172955,Walking,2,0,all,2km ≥ walking
+20-39,females,Base case,commuting_2_0,0.011733417081580372,Cycling,2,0,commuting,2km ≥ walking
+20-39,females,Base case,commuting_2_0,0.5652262788833393,Car,2,0,commuting,2km ≥ walking
+20-39,females,Base case,commuting_2_0,0.005432591007426083,Other,2,0,commuting,2km ≥ walking
+20-39,females,Base case,commuting_2_0,0.11250143927592476,Public transport,2,0,commuting,2km ≥ walking
+20-39,females,Base case,commuting_2_0,0.30510627375172955,Walking,2,0,commuting,2km ≥ walking
+20-39,females,Base case,all_2_5,0.011733417081580372,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Base case,all_2_5,0.5652262788833393,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Base case,all_2_5,0.005432591007426083,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Base case,all_2_5,0.11250143927592476,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Base case,all_2_5,0.30510627375172955,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Base case,commuting_2_5,0.011733417081580372,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Base case,commuting_2_5,0.5652262788833393,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Base case,commuting_2_5,0.005432591007426083,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Base case,commuting_2_5,0.11250143927592476,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Base case,commuting_2_5,0.30510627375172955,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Scenario,all_0_2,0.10361089456096581,Cycling,0,2,all,2km ≥ cycling
+20-39,females,Scenario,all_0_2,0.47334880140395386,Car,0,2,all,2km ≥ cycling
+20-39,females,Scenario,all_0_2,0.005432591007426083,Other,0,2,all,2km ≥ cycling
+20-39,females,Scenario,all_0_2,0.11250143927592476,Public transport,0,2,all,2km ≥ cycling
+20-39,females,Scenario,all_0_2,0.30510627375172955,Walking,0,2,all,2km ≥ cycling
+20-39,females,Scenario,commuting_0_2,0.021549878203687756,Cycling,0,2,commuting,2km ≥ cycling
+20-39,females,Scenario,commuting_0_2,0.5554098177612319,Car,0,2,commuting,2km ≥ cycling
+20-39,females,Scenario,commuting_0_2,0.005432591007426083,Other,0,2,commuting,2km ≥ cycling
+20-39,females,Scenario,commuting_0_2,0.11250143927592476,Public transport,0,2,commuting,2km ≥ cycling
+20-39,females,Scenario,commuting_0_2,0.30510627375172955,Walking,0,2,commuting,2km ≥ cycling
+20-39,females,Scenario,all_0_5,0.2603294492848286,Cycling,0,5,all,5km ≥ cycling
+20-39,females,Scenario,all_0_5,0.31663024668009104,Car,0,5,all,5km ≥ cycling
+20-39,females,Scenario,all_0_5,0.005432591007426083,Other,0,5,all,5km ≥ cycling
+20-39,females,Scenario,all_0_5,0.11250143927592476,Public transport,0,5,all,5km ≥ cycling
+20-39,females,Scenario,all_0_5,0.30510627375172955,Walking,0,5,all,5km ≥ cycling
+20-39,females,Scenario,commuting_0_5,0.05005149037656253,Cycling,0,5,commuting,5km ≥ cycling
+20-39,females,Scenario,commuting_0_5,0.5269082055883572,Car,0,5,commuting,5km ≥ cycling
+20-39,females,Scenario,commuting_0_5,0.005432591007426083,Other,0,5,commuting,5km ≥ cycling
+20-39,females,Scenario,commuting_0_5,0.11250143927592476,Public transport,0,5,commuting,5km ≥ cycling
+20-39,females,Scenario,commuting_0_5,0.30510627375172955,Walking,0,5,commuting,5km ≥ cycling
+20-39,females,Scenario,all_1_0,0.011733417081580372,Cycling,1,0,all,1km ≥ walking
+20-39,females,Scenario,all_1_0,0.5410126904978846,Car,1,0,all,1km ≥ walking
+20-39,females,Scenario,all_1_0,0.005432591007426083,Other,1,0,all,1km ≥ walking
+20-39,females,Scenario,all_1_0,0.11250143927592476,Public transport,1,0,all,1km ≥ walking
+20-39,females,Scenario,all_1_0,0.3293198621371843,Walking,1,0,all,1km ≥ walking
+20-39,females,Scenario,commuting_1_0,0.011733417081580372,Cycling,1,0,commuting,1km ≥ walking
+20-39,females,Scenario,commuting_1_0,0.5632518474831824,Car,1,0,commuting,1km ≥ walking
+20-39,females,Scenario,commuting_1_0,0.005432591007426083,Other,1,0,commuting,1km ≥ walking
+20-39,females,Scenario,commuting_1_0,0.11250143927592476,Public transport,1,0,commuting,1km ≥ walking
+20-39,females,Scenario,commuting_1_0,0.30708070515188646,Walking,1,0,commuting,1km ≥ walking
+20-39,females,Scenario,all_1_2,0.07939730617551109,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Scenario,all_1_2,0.47334880140395386,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Scenario,all_1_2,0.005432591007426083,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Scenario,all_1_2,0.11250143927592476,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Scenario,all_1_2,0.3293198621371843,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Scenario,commuting_1_2,0.01957544680353087,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Scenario,commuting_1_2,0.5554098177612319,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Scenario,commuting_1_2,0.005432591007426083,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Scenario,commuting_1_2,0.11250143927592476,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Scenario,commuting_1_2,0.30708070515188646,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females,Scenario,all_1_5,0.2361158608993739,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Scenario,all_1_5,0.31663024668009104,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Scenario,all_1_5,0.005432591007426083,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Scenario,all_1_5,0.11250143927592476,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Scenario,all_1_5,0.3293198621371843,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Scenario,commuting_1_5,0.04807705897640564,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Scenario,commuting_1_5,0.5269082055883572,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Scenario,commuting_1_5,0.005432591007426083,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Scenario,commuting_1_5,0.11250143927592476,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Scenario,commuting_1_5,0.30708070515188646,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females,Scenario,all_2_0,0.011733417081580372,Cycling,2,0,all,2km ≥ walking
+20-39,females,Scenario,all_2_0,0.47334880140395386,Car,2,0,all,2km ≥ walking
+20-39,females,Scenario,all_2_0,0.005432591007426083,Other,2,0,all,2km ≥ walking
+20-39,females,Scenario,all_2_0,0.11250143927592476,Public transport,2,0,all,2km ≥ walking
+20-39,females,Scenario,all_2_0,0.396983751231115,Walking,2,0,all,2km ≥ walking
+20-39,females,Scenario,commuting_2_0,0.011733417081580372,Cycling,2,0,commuting,2km ≥ walking
+20-39,females,Scenario,commuting_2_0,0.5554098177612319,Car,2,0,commuting,2km ≥ walking
+20-39,females,Scenario,commuting_2_0,0.005432591007426083,Other,2,0,commuting,2km ≥ walking
+20-39,females,Scenario,commuting_2_0,0.11250143927592476,Public transport,2,0,commuting,2km ≥ walking
+20-39,females,Scenario,commuting_2_0,0.31492273487383693,Walking,2,0,commuting,2km ≥ walking
+20-39,females,Scenario,all_2_5,0.16845197180544316,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Scenario,all_2_5,0.31663024668009104,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Scenario,all_2_5,0.005432591007426083,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Scenario,all_2_5,0.11250143927592476,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Scenario,all_2_5,0.396983751231115,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Scenario,commuting_2_5,0.04023502925445514,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Scenario,commuting_2_5,0.5269082055883572,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Scenario,commuting_2_5,0.005432591007426083,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Scenario,commuting_2_5,0.11250143927592476,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females,Scenario,commuting_2_5,0.31492273487383693,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Base case,all_0_2,0.014052447472186366,Cycling,0,2,all,2km ≥ cycling
+20-39,females and males,Base case,all_0_2,0.5791822931953814,Car,0,2,all,2km ≥ cycling
+20-39,females and males,Base case,all_0_2,0.007408474176305872,Other,0,2,all,2km ≥ cycling
+20-39,females and males,Base case,all_0_2,0.1122053304730624,Public transport,0,2,all,2km ≥ cycling
+20-39,females and males,Base case,all_0_2,0.287151454683064,Walking,0,2,all,2km ≥ cycling
+20-39,females and males,Base case,commuting_0_2,0.014052447472186366,Cycling,0,2,commuting,2km ≥ cycling
+20-39,females and males,Base case,commuting_0_2,0.5791822931953814,Car,0,2,commuting,2km ≥ cycling
+20-39,females and males,Base case,commuting_0_2,0.007408474176305872,Other,0,2,commuting,2km ≥ cycling
+20-39,females and males,Base case,commuting_0_2,0.1122053304730624,Public transport,0,2,commuting,2km ≥ cycling
+20-39,females and males,Base case,commuting_0_2,0.287151454683064,Walking,0,2,commuting,2km ≥ cycling
+20-39,females and males,Base case,all_0_5,0.014052447472186366,Cycling,0,5,all,5km ≥ cycling
+20-39,females and males,Base case,all_0_5,0.5791822931953814,Car,0,5,all,5km ≥ cycling
+20-39,females and males,Base case,all_0_5,0.007408474176305872,Other,0,5,all,5km ≥ cycling
+20-39,females and males,Base case,all_0_5,0.1122053304730624,Public transport,0,5,all,5km ≥ cycling
+20-39,females and males,Base case,all_0_5,0.287151454683064,Walking,0,5,all,5km ≥ cycling
+20-39,females and males,Base case,commuting_0_5,0.014052447472186366,Cycling,0,5,commuting,5km ≥ cycling
+20-39,females and males,Base case,commuting_0_5,0.5791822931953814,Car,0,5,commuting,5km ≥ cycling
+20-39,females and males,Base case,commuting_0_5,0.007408474176305872,Other,0,5,commuting,5km ≥ cycling
+20-39,females and males,Base case,commuting_0_5,0.1122053304730624,Public transport,0,5,commuting,5km ≥ cycling
+20-39,females and males,Base case,commuting_0_5,0.287151454683064,Walking,0,5,commuting,5km ≥ cycling
+20-39,females and males,Base case,all_1_0,0.014052447472186366,Cycling,1,0,all,1km ≥ walking
+20-39,females and males,Base case,all_1_0,0.5791822931953814,Car,1,0,all,1km ≥ walking
+20-39,females and males,Base case,all_1_0,0.007408474176305872,Other,1,0,all,1km ≥ walking
+20-39,females and males,Base case,all_1_0,0.1122053304730624,Public transport,1,0,all,1km ≥ walking
+20-39,females and males,Base case,all_1_0,0.287151454683064,Walking,1,0,all,1km ≥ walking
+20-39,females and males,Base case,commuting_1_0,0.014052447472186366,Cycling,1,0,commuting,1km ≥ walking
+20-39,females and males,Base case,commuting_1_0,0.5791822931953814,Car,1,0,commuting,1km ≥ walking
+20-39,females and males,Base case,commuting_1_0,0.007408474176305872,Other,1,0,commuting,1km ≥ walking
+20-39,females and males,Base case,commuting_1_0,0.1122053304730624,Public transport,1,0,commuting,1km ≥ walking
+20-39,females and males,Base case,commuting_1_0,0.287151454683064,Walking,1,0,commuting,1km ≥ walking
+20-39,females and males,Base case,all_1_2,0.014052447472186366,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Base case,all_1_2,0.5791822931953814,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Base case,all_1_2,0.007408474176305872,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Base case,all_1_2,0.1122053304730624,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Base case,all_1_2,0.287151454683064,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Base case,commuting_1_2,0.014052447472186366,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Base case,commuting_1_2,0.5791822931953814,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Base case,commuting_1_2,0.007408474176305872,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Base case,commuting_1_2,0.1122053304730624,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Base case,commuting_1_2,0.287151454683064,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Base case,all_1_5,0.014052447472186366,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Base case,all_1_5,0.5791822931953814,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Base case,all_1_5,0.007408474176305872,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Base case,all_1_5,0.1122053304730624,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Base case,all_1_5,0.287151454683064,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Base case,commuting_1_5,0.014052447472186366,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Base case,commuting_1_5,0.5791822931953814,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Base case,commuting_1_5,0.007408474176305872,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Base case,commuting_1_5,0.1122053304730624,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Base case,commuting_1_5,0.287151454683064,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Base case,all_2_0,0.014052447472186366,Cycling,2,0,all,2km ≥ walking
+20-39,females and males,Base case,all_2_0,0.5791822931953814,Car,2,0,all,2km ≥ walking
+20-39,females and males,Base case,all_2_0,0.007408474176305872,Other,2,0,all,2km ≥ walking
+20-39,females and males,Base case,all_2_0,0.1122053304730624,Public transport,2,0,all,2km ≥ walking
+20-39,females and males,Base case,all_2_0,0.287151454683064,Walking,2,0,all,2km ≥ walking
+20-39,females and males,Base case,commuting_2_0,0.014052447472186366,Cycling,2,0,commuting,2km ≥ walking
+20-39,females and males,Base case,commuting_2_0,0.5791822931953814,Car,2,0,commuting,2km ≥ walking
+20-39,females and males,Base case,commuting_2_0,0.007408474176305872,Other,2,0,commuting,2km ≥ walking
+20-39,females and males,Base case,commuting_2_0,0.1122053304730624,Public transport,2,0,commuting,2km ≥ walking
+20-39,females and males,Base case,commuting_2_0,0.287151454683064,Walking,2,0,commuting,2km ≥ walking
+20-39,females and males,Base case,all_2_5,0.014052447472186366,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Base case,all_2_5,0.5791822931953814,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Base case,all_2_5,0.007408474176305872,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Base case,all_2_5,0.1122053304730624,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Base case,all_2_5,0.287151454683064,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Base case,commuting_2_5,0.014052447472186366,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Base case,commuting_2_5,0.5791822931953814,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Base case,commuting_2_5,0.007408474176305872,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Base case,commuting_2_5,0.1122053304730624,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Base case,commuting_2_5,0.287151454683064,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Scenario,all_0_2,0.1018456100867717,Cycling,0,2,all,2km ≥ cycling
+20-39,females and males,Scenario,all_0_2,0.49138913058079603,Car,0,2,all,2km ≥ cycling
+20-39,females and males,Scenario,all_0_2,0.007408474176305872,Other,0,2,all,2km ≥ cycling
+20-39,females and males,Scenario,all_0_2,0.1122053304730624,Public transport,0,2,all,2km ≥ cycling
+20-39,females and males,Scenario,all_0_2,0.287151454683064,Walking,0,2,all,2km ≥ cycling
+20-39,females and males,Scenario,commuting_0_2,0.02568267619274725,Cycling,0,2,commuting,2km ≥ cycling
+20-39,females and males,Scenario,commuting_0_2,0.5675520644748205,Car,0,2,commuting,2km ≥ cycling
+20-39,females and males,Scenario,commuting_0_2,0.007408474176305872,Other,0,2,commuting,2km ≥ cycling
+20-39,females and males,Scenario,commuting_0_2,0.1122053304730624,Public transport,0,2,commuting,2km ≥ cycling
+20-39,females and males,Scenario,commuting_0_2,0.287151454683064,Walking,0,2,commuting,2km ≥ cycling
+20-39,females and males,Scenario,all_0_5,0.24577612304398125,Cycling,0,5,all,5km ≥ cycling
+20-39,females and males,Scenario,all_0_5,0.3474586176235865,Car,0,5,all,5km ≥ cycling
+20-39,females and males,Scenario,all_0_5,0.007408474176305872,Other,0,5,all,5km ≥ cycling
+20-39,females and males,Scenario,all_0_5,0.1122053304730624,Public transport,0,5,all,5km ≥ cycling
+20-39,females and males,Scenario,all_0_5,0.287151454683064,Walking,0,5,all,5km ≥ cycling
+20-39,females and males,Scenario,commuting_0_5,0.05401299575579687,Cycling,0,5,commuting,5km ≥ cycling
+20-39,females and males,Scenario,commuting_0_5,0.5392217449117709,Car,0,5,commuting,5km ≥ cycling
+20-39,females and males,Scenario,commuting_0_5,0.007408474176305872,Other,0,5,commuting,5km ≥ cycling
+20-39,females and males,Scenario,commuting_0_5,0.1122053304730624,Public transport,0,5,commuting,5km ≥ cycling
+20-39,females and males,Scenario,commuting_0_5,0.287151454683064,Walking,0,5,commuting,5km ≥ cycling
+20-39,females and males,Scenario,all_1_0,0.014052447472186366,Cycling,1,0,all,1km ≥ walking
+20-39,females and males,Scenario,all_1_0,0.5547274322079643,Car,1,0,all,1km ≥ walking
+20-39,females and males,Scenario,all_1_0,0.007408474176305872,Other,1,0,all,1km ≥ walking
+20-39,females and males,Scenario,all_1_0,0.1122053304730624,Public transport,1,0,all,1km ≥ walking
+20-39,females and males,Scenario,all_1_0,0.31160631567048114,Walking,1,0,all,1km ≥ walking
+20-39,females and males,Scenario,commuting_1_0,0.014052447472186366,Cycling,1,0,commuting,1km ≥ walking
+20-39,females and males,Scenario,commuting_1_0,0.5760516215601379,Car,1,0,commuting,1km ≥ walking
+20-39,females and males,Scenario,commuting_1_0,0.007408474176305872,Other,1,0,commuting,1km ≥ walking
+20-39,females and males,Scenario,commuting_1_0,0.1122053304730624,Public transport,1,0,commuting,1km ≥ walking
+20-39,females and males,Scenario,commuting_1_0,0.2902821263183075,Walking,1,0,commuting,1km ≥ walking
+20-39,females and males,Scenario,all_1_2,0.07739074909935457,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Scenario,all_1_2,0.49138913058079603,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Scenario,all_1_2,0.007408474176305872,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Scenario,all_1_2,0.1122053304730624,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Scenario,all_1_2,0.31160631567048114,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Scenario,commuting_1_2,0.02255200455750376,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Scenario,commuting_1_2,0.5675520644748205,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Scenario,commuting_1_2,0.007408474176305872,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Scenario,commuting_1_2,0.1122053304730624,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Scenario,commuting_1_2,0.2902821263183075,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+20-39,females and males,Scenario,all_1_5,0.2213212620565641,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Scenario,all_1_5,0.3474586176235865,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Scenario,all_1_5,0.007408474176305872,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Scenario,all_1_5,0.1122053304730624,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Scenario,all_1_5,0.31160631567048114,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Scenario,commuting_1_5,0.05088232412055338,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Scenario,commuting_1_5,0.5392217449117709,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Scenario,commuting_1_5,0.007408474176305872,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Scenario,commuting_1_5,0.1122053304730624,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Scenario,commuting_1_5,0.2902821263183075,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+20-39,females and males,Scenario,all_2_0,0.014052447472186366,Cycling,2,0,all,2km ≥ walking
+20-39,females and males,Scenario,all_2_0,0.49138913058079603,Car,2,0,all,2km ≥ walking
+20-39,females and males,Scenario,all_2_0,0.007408474176305872,Other,2,0,all,2km ≥ walking
+20-39,females and males,Scenario,all_2_0,0.1122053304730624,Public transport,2,0,all,2km ≥ walking
+20-39,females and males,Scenario,all_2_0,0.37494461729764933,Walking,2,0,all,2km ≥ walking
+20-39,females and males,Scenario,commuting_2_0,0.014052447472186366,Cycling,2,0,commuting,2km ≥ walking
+20-39,females and males,Scenario,commuting_2_0,0.5675520644748205,Car,2,0,commuting,2km ≥ walking
+20-39,females and males,Scenario,commuting_2_0,0.007408474176305872,Other,2,0,commuting,2km ≥ walking
+20-39,females and males,Scenario,commuting_2_0,0.1122053304730624,Public transport,2,0,commuting,2km ≥ walking
+20-39,females and males,Scenario,commuting_2_0,0.2987816834036249,Walking,2,0,commuting,2km ≥ walking
+20-39,females and males,Scenario,all_2_5,0.1579829604293959,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Scenario,all_2_5,0.3474586176235865,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Scenario,all_2_5,0.007408474176305872,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Scenario,all_2_5,0.1122053304730624,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Scenario,all_2_5,0.37494461729764933,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Scenario,commuting_2_5,0.04238276703523599,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Scenario,commuting_2_5,0.5392217449117709,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Scenario,commuting_2_5,0.007408474176305872,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Scenario,commuting_2_5,0.1122053304730624,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+20-39,females and males,Scenario,commuting_2_5,0.2987816834036249,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Base case,all_0_2,0.018464237813515468,Cycling,0,2,all,2km ≥ cycling
+all age groups,males,Base case,all_0_2,0.631459398182303,Car,0,2,all,2km ≥ cycling
+all age groups,males,Base case,all_0_2,0.008698255560090472,Other,0,2,all,2km ≥ cycling
+all age groups,males,Base case,all_0_2,0.08576283202345988,Public transport,0,2,all,2km ≥ cycling
+all age groups,males,Base case,all_0_2,0.25561527642063114,Walking,0,2,all,2km ≥ cycling
+all age groups,males,Base case,commuting_0_2,0.018464237813515468,Cycling,0,2,commuting,2km ≥ cycling
+all age groups,males,Base case,commuting_0_2,0.631459398182303,Car,0,2,commuting,2km ≥ cycling
+all age groups,males,Base case,commuting_0_2,0.008698255560090472,Other,0,2,commuting,2km ≥ cycling
+all age groups,males,Base case,commuting_0_2,0.08576283202345988,Public transport,0,2,commuting,2km ≥ cycling
+all age groups,males,Base case,commuting_0_2,0.25561527642063114,Walking,0,2,commuting,2km ≥ cycling
+all age groups,males,Base case,all_0_5,0.018464237813515468,Cycling,0,5,all,5km ≥ cycling
+all age groups,males,Base case,all_0_5,0.631459398182303,Car,0,5,all,5km ≥ cycling
+all age groups,males,Base case,all_0_5,0.008698255560090472,Other,0,5,all,5km ≥ cycling
+all age groups,males,Base case,all_0_5,0.08576283202345988,Public transport,0,5,all,5km ≥ cycling
+all age groups,males,Base case,all_0_5,0.25561527642063114,Walking,0,5,all,5km ≥ cycling
+all age groups,males,Base case,commuting_0_5,0.018464237813515468,Cycling,0,5,commuting,5km ≥ cycling
+all age groups,males,Base case,commuting_0_5,0.631459398182303,Car,0,5,commuting,5km ≥ cycling
+all age groups,males,Base case,commuting_0_5,0.008698255560090472,Other,0,5,commuting,5km ≥ cycling
+all age groups,males,Base case,commuting_0_5,0.08576283202345988,Public transport,0,5,commuting,5km ≥ cycling
+all age groups,males,Base case,commuting_0_5,0.25561527642063114,Walking,0,5,commuting,5km ≥ cycling
+all age groups,males,Base case,all_1_0,0.018464237813515468,Cycling,1,0,all,1km ≥ walking
+all age groups,males,Base case,all_1_0,0.631459398182303,Car,1,0,all,1km ≥ walking
+all age groups,males,Base case,all_1_0,0.008698255560090472,Other,1,0,all,1km ≥ walking
+all age groups,males,Base case,all_1_0,0.08576283202345988,Public transport,1,0,all,1km ≥ walking
+all age groups,males,Base case,all_1_0,0.25561527642063114,Walking,1,0,all,1km ≥ walking
+all age groups,males,Base case,commuting_1_0,0.018464237813515468,Cycling,1,0,commuting,1km ≥ walking
+all age groups,males,Base case,commuting_1_0,0.631459398182303,Car,1,0,commuting,1km ≥ walking
+all age groups,males,Base case,commuting_1_0,0.008698255560090472,Other,1,0,commuting,1km ≥ walking
+all age groups,males,Base case,commuting_1_0,0.08576283202345988,Public transport,1,0,commuting,1km ≥ walking
+all age groups,males,Base case,commuting_1_0,0.25561527642063114,Walking,1,0,commuting,1km ≥ walking
+all age groups,males,Base case,all_1_2,0.018464237813515468,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Base case,all_1_2,0.631459398182303,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Base case,all_1_2,0.008698255560090472,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Base case,all_1_2,0.08576283202345988,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Base case,all_1_2,0.25561527642063114,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Base case,commuting_1_2,0.018464237813515468,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Base case,commuting_1_2,0.631459398182303,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Base case,commuting_1_2,0.008698255560090472,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Base case,commuting_1_2,0.08576283202345988,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Base case,commuting_1_2,0.25561527642063114,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Base case,all_1_5,0.018464237813515468,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Base case,all_1_5,0.631459398182303,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Base case,all_1_5,0.008698255560090472,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Base case,all_1_5,0.08576283202345988,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Base case,all_1_5,0.25561527642063114,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Base case,commuting_1_5,0.018464237813515468,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Base case,commuting_1_5,0.631459398182303,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Base case,commuting_1_5,0.008698255560090472,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Base case,commuting_1_5,0.08576283202345988,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Base case,commuting_1_5,0.25561527642063114,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Base case,all_2_0,0.018464237813515468,Cycling,2,0,all,2km ≥ walking
+all age groups,males,Base case,all_2_0,0.631459398182303,Car,2,0,all,2km ≥ walking
+all age groups,males,Base case,all_2_0,0.008698255560090472,Other,2,0,all,2km ≥ walking
+all age groups,males,Base case,all_2_0,0.08576283202345988,Public transport,2,0,all,2km ≥ walking
+all age groups,males,Base case,all_2_0,0.25561527642063114,Walking,2,0,all,2km ≥ walking
+all age groups,males,Base case,commuting_2_0,0.018464237813515468,Cycling,2,0,commuting,2km ≥ walking
+all age groups,males,Base case,commuting_2_0,0.631459398182303,Car,2,0,commuting,2km ≥ walking
+all age groups,males,Base case,commuting_2_0,0.008698255560090472,Other,2,0,commuting,2km ≥ walking
+all age groups,males,Base case,commuting_2_0,0.08576283202345988,Public transport,2,0,commuting,2km ≥ walking
+all age groups,males,Base case,commuting_2_0,0.25561527642063114,Walking,2,0,commuting,2km ≥ walking
+all age groups,males,Base case,all_2_5,0.018464237813515468,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Base case,all_2_5,0.631459398182303,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Base case,all_2_5,0.008698255560090472,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Base case,all_2_5,0.08576283202345988,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Base case,all_2_5,0.25561527642063114,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Base case,commuting_2_5,0.018464237813515468,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Base case,commuting_2_5,0.631459398182303,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Base case,commuting_2_5,0.008698255560090472,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Base case,commuting_2_5,0.08576283202345988,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Base case,commuting_2_5,0.25561527642063114,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Scenario,all_0_2,0.11788409270936828,Cycling,0,2,all,2km ≥ cycling
+all age groups,males,Scenario,all_0_2,0.5320395432864502,Car,0,2,all,2km ≥ cycling
+all age groups,males,Scenario,all_0_2,0.008698255560090472,Other,0,2,all,2km ≥ cycling
+all age groups,males,Scenario,all_0_2,0.08576283202345988,Public transport,0,2,all,2km ≥ cycling
+all age groups,males,Scenario,all_0_2,0.25561527642063114,Walking,0,2,all,2km ≥ cycling
+all age groups,males,Scenario,commuting_0_2,0.030606984264122842,Cycling,0,2,commuting,2km ≥ cycling
+all age groups,males,Scenario,commuting_0_2,0.6193166517316957,Car,0,2,commuting,2km ≥ cycling
+all age groups,males,Scenario,commuting_0_2,0.008698255560090472,Other,0,2,commuting,2km ≥ cycling
+all age groups,males,Scenario,commuting_0_2,0.08576283202345988,Public transport,0,2,commuting,2km ≥ cycling
+all age groups,males,Scenario,commuting_0_2,0.25561527642063114,Walking,0,2,commuting,2km ≥ cycling
+all age groups,males,Scenario,all_0_5,0.2828549624501351,Cycling,0,5,all,5km ≥ cycling
+all age groups,males,Scenario,all_0_5,0.3670686735456834,Car,0,5,all,5km ≥ cycling
+all age groups,males,Scenario,all_0_5,0.008698255560090472,Other,0,5,all,5km ≥ cycling
+all age groups,males,Scenario,all_0_5,0.08576283202345988,Public transport,0,5,all,5km ≥ cycling
+all age groups,males,Scenario,all_0_5,0.25561527642063114,Walking,0,5,all,5km ≥ cycling
+all age groups,males,Scenario,commuting_0_5,0.05497637732231966,Cycling,0,5,commuting,5km ≥ cycling
+all age groups,males,Scenario,commuting_0_5,0.5949472586734988,Car,0,5,commuting,5km ≥ cycling
+all age groups,males,Scenario,commuting_0_5,0.008698255560090472,Other,0,5,commuting,5km ≥ cycling
+all age groups,males,Scenario,commuting_0_5,0.08576283202345988,Public transport,0,5,commuting,5km ≥ cycling
+all age groups,males,Scenario,commuting_0_5,0.25561527642063114,Walking,0,5,commuting,5km ≥ cycling
+all age groups,males,Scenario,all_1_0,0.018464237813515468,Cycling,1,0,all,1km ≥ walking
+all age groups,males,Scenario,all_1_0,0.6018187452217348,Car,1,0,all,1km ≥ walking
+all age groups,males,Scenario,all_1_0,0.008698255560090472,Other,1,0,all,1km ≥ walking
+all age groups,males,Scenario,all_1_0,0.08576283202345988,Public transport,1,0,all,1km ≥ walking
+all age groups,males,Scenario,all_1_0,0.28525592938119937,Walking,1,0,all,1km ≥ walking
+all age groups,males,Scenario,commuting_1_0,0.018464237813515468,Cycling,1,0,commuting,1km ≥ walking
+all age groups,males,Scenario,commuting_1_0,0.6275114400046803,Car,1,0,commuting,1km ≥ walking
+all age groups,males,Scenario,commuting_1_0,0.008698255560090472,Other,1,0,commuting,1km ≥ walking
+all age groups,males,Scenario,commuting_1_0,0.08576283202345988,Public transport,1,0,commuting,1km ≥ walking
+all age groups,males,Scenario,commuting_1_0,0.2595632345982539,Walking,1,0,commuting,1km ≥ walking
+all age groups,males,Scenario,all_1_2,0.08824343974880004,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Scenario,all_1_2,0.5320395432864502,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Scenario,all_1_2,0.008698255560090472,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Scenario,all_1_2,0.08576283202345988,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Scenario,all_1_2,0.28525592938119937,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Scenario,commuting_1_2,0.026659026086500066,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Scenario,commuting_1_2,0.6193166517316957,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Scenario,commuting_1_2,0.008698255560090472,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Scenario,commuting_1_2,0.08576283202345988,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Scenario,commuting_1_2,0.2595632345982539,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,males,Scenario,all_1_5,0.25321430948956686,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Scenario,all_1_5,0.3670686735456834,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Scenario,all_1_5,0.008698255560090472,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Scenario,all_1_5,0.08576283202345988,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Scenario,all_1_5,0.28525592938119937,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Scenario,commuting_1_5,0.051028419144696885,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Scenario,commuting_1_5,0.5949472586734988,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Scenario,commuting_1_5,0.008698255560090472,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Scenario,commuting_1_5,0.08576283202345988,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Scenario,commuting_1_5,0.2595632345982539,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,males,Scenario,all_2_0,0.018464237813515468,Cycling,2,0,all,2km ≥ walking
+all age groups,males,Scenario,all_2_0,0.5320395432864502,Car,2,0,all,2km ≥ walking
+all age groups,males,Scenario,all_2_0,0.008698255560090472,Other,2,0,all,2km ≥ walking
+all age groups,males,Scenario,all_2_0,0.08576283202345988,Public transport,2,0,all,2km ≥ walking
+all age groups,males,Scenario,all_2_0,0.35503513131648395,Walking,2,0,all,2km ≥ walking
+all age groups,males,Scenario,commuting_2_0,0.018464237813515468,Cycling,2,0,commuting,2km ≥ walking
+all age groups,males,Scenario,commuting_2_0,0.6193166517316957,Car,2,0,commuting,2km ≥ walking
+all age groups,males,Scenario,commuting_2_0,0.008698255560090472,Other,2,0,commuting,2km ≥ walking
+all age groups,males,Scenario,commuting_2_0,0.08576283202345988,Public transport,2,0,commuting,2km ≥ walking
+all age groups,males,Scenario,commuting_2_0,0.2677580228712385,Walking,2,0,commuting,2km ≥ walking
+all age groups,males,Scenario,all_2_5,0.1834351075542823,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Scenario,all_2_5,0.3670686735456834,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Scenario,all_2_5,0.008698255560090472,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Scenario,all_2_5,0.08576283202345988,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Scenario,all_2_5,0.35503513131648395,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Scenario,commuting_2_5,0.04283363087171228,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Scenario,commuting_2_5,0.5949472586734988,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Scenario,commuting_2_5,0.008698255560090472,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Scenario,commuting_2_5,0.08576283202345988,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,males,Scenario,commuting_2_5,0.2677580228712385,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Base case,all_0_2,0.008105780410790651,Cycling,0,2,all,2km ≥ cycling
+all age groups,females,Base case,all_0_2,0.6262529893379819,Car,0,2,all,2km ≥ cycling
+all age groups,females,Base case,all_0_2,0.0058605157707603975,Other,0,2,all,2km ≥ cycling
+all age groups,females,Base case,all_0_2,0.08243106095926937,Public transport,0,2,all,2km ≥ cycling
+all age groups,females,Base case,all_0_2,0.2773496535211976,Walking,0,2,all,2km ≥ cycling
+all age groups,females,Base case,commuting_0_2,0.008105780410790651,Cycling,0,2,commuting,2km ≥ cycling
+all age groups,females,Base case,commuting_0_2,0.6262529893379819,Car,0,2,commuting,2km ≥ cycling
+all age groups,females,Base case,commuting_0_2,0.0058605157707603975,Other,0,2,commuting,2km ≥ cycling
+all age groups,females,Base case,commuting_0_2,0.08243106095926937,Public transport,0,2,commuting,2km ≥ cycling
+all age groups,females,Base case,commuting_0_2,0.2773496535211976,Walking,0,2,commuting,2km ≥ cycling
+all age groups,females,Base case,all_0_5,0.008105780410790651,Cycling,0,5,all,5km ≥ cycling
+all age groups,females,Base case,all_0_5,0.6262529893379819,Car,0,5,all,5km ≥ cycling
+all age groups,females,Base case,all_0_5,0.0058605157707603975,Other,0,5,all,5km ≥ cycling
+all age groups,females,Base case,all_0_5,0.08243106095926937,Public transport,0,5,all,5km ≥ cycling
+all age groups,females,Base case,all_0_5,0.2773496535211976,Walking,0,5,all,5km ≥ cycling
+all age groups,females,Base case,commuting_0_5,0.008105780410790651,Cycling,0,5,commuting,5km ≥ cycling
+all age groups,females,Base case,commuting_0_5,0.6262529893379819,Car,0,5,commuting,5km ≥ cycling
+all age groups,females,Base case,commuting_0_5,0.0058605157707603975,Other,0,5,commuting,5km ≥ cycling
+all age groups,females,Base case,commuting_0_5,0.08243106095926937,Public transport,0,5,commuting,5km ≥ cycling
+all age groups,females,Base case,commuting_0_5,0.2773496535211976,Walking,0,5,commuting,5km ≥ cycling
+all age groups,females,Base case,all_1_0,0.008105780410790651,Cycling,1,0,all,1km ≥ walking
+all age groups,females,Base case,all_1_0,0.6262529893379819,Car,1,0,all,1km ≥ walking
+all age groups,females,Base case,all_1_0,0.0058605157707603975,Other,1,0,all,1km ≥ walking
+all age groups,females,Base case,all_1_0,0.08243106095926937,Public transport,1,0,all,1km ≥ walking
+all age groups,females,Base case,all_1_0,0.2773496535211976,Walking,1,0,all,1km ≥ walking
+all age groups,females,Base case,commuting_1_0,0.008105780410790651,Cycling,1,0,commuting,1km ≥ walking
+all age groups,females,Base case,commuting_1_0,0.6262529893379819,Car,1,0,commuting,1km ≥ walking
+all age groups,females,Base case,commuting_1_0,0.0058605157707603975,Other,1,0,commuting,1km ≥ walking
+all age groups,females,Base case,commuting_1_0,0.08243106095926937,Public transport,1,0,commuting,1km ≥ walking
+all age groups,females,Base case,commuting_1_0,0.2773496535211976,Walking,1,0,commuting,1km ≥ walking
+all age groups,females,Base case,all_1_2,0.008105780410790651,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Base case,all_1_2,0.6262529893379819,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Base case,all_1_2,0.0058605157707603975,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Base case,all_1_2,0.08243106095926937,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Base case,all_1_2,0.2773496535211976,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Base case,commuting_1_2,0.008105780410790651,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Base case,commuting_1_2,0.6262529893379819,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Base case,commuting_1_2,0.0058605157707603975,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Base case,commuting_1_2,0.08243106095926937,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Base case,commuting_1_2,0.2773496535211976,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Base case,all_1_5,0.008105780410790651,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Base case,all_1_5,0.6262529893379819,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Base case,all_1_5,0.0058605157707603975,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Base case,all_1_5,0.08243106095926937,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Base case,all_1_5,0.2773496535211976,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Base case,commuting_1_5,0.008105780410790651,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Base case,commuting_1_5,0.6262529893379819,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Base case,commuting_1_5,0.0058605157707603975,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Base case,commuting_1_5,0.08243106095926937,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Base case,commuting_1_5,0.2773496535211976,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Base case,all_2_0,0.008105780410790651,Cycling,2,0,all,2km ≥ walking
+all age groups,females,Base case,all_2_0,0.6262529893379819,Car,2,0,all,2km ≥ walking
+all age groups,females,Base case,all_2_0,0.0058605157707603975,Other,2,0,all,2km ≥ walking
+all age groups,females,Base case,all_2_0,0.08243106095926937,Public transport,2,0,all,2km ≥ walking
+all age groups,females,Base case,all_2_0,0.2773496535211976,Walking,2,0,all,2km ≥ walking
+all age groups,females,Base case,commuting_2_0,0.008105780410790651,Cycling,2,0,commuting,2km ≥ walking
+all age groups,females,Base case,commuting_2_0,0.6262529893379819,Car,2,0,commuting,2km ≥ walking
+all age groups,females,Base case,commuting_2_0,0.0058605157707603975,Other,2,0,commuting,2km ≥ walking
+all age groups,females,Base case,commuting_2_0,0.08243106095926937,Public transport,2,0,commuting,2km ≥ walking
+all age groups,females,Base case,commuting_2_0,0.2773496535211976,Walking,2,0,commuting,2km ≥ walking
+all age groups,females,Base case,all_2_5,0.008105780410790651,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Base case,all_2_5,0.6262529893379819,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Base case,all_2_5,0.0058605157707603975,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Base case,all_2_5,0.08243106095926937,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Base case,all_2_5,0.2773496535211976,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Base case,commuting_2_5,0.008105780410790651,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Base case,commuting_2_5,0.6262529893379819,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Base case,commuting_2_5,0.0058605157707603975,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Base case,commuting_2_5,0.08243106095926937,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Base case,commuting_2_5,0.2773496535211976,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Scenario,all_0_2,0.12275873860551102,Cycling,0,2,all,2km ≥ cycling
+all age groups,females,Scenario,all_0_2,0.5116000311432616,Car,0,2,all,2km ≥ cycling
+all age groups,females,Scenario,all_0_2,0.0058605157707603975,Other,0,2,all,2km ≥ cycling
+all age groups,females,Scenario,all_0_2,0.08243106095926937,Public transport,0,2,all,2km ≥ cycling
+all age groups,females,Scenario,all_0_2,0.2773496535211976,Walking,0,2,all,2km ≥ cycling
+all age groups,females,Scenario,commuting_0_2,0.019561512045772462,Cycling,0,2,commuting,2km ≥ cycling
+all age groups,females,Scenario,commuting_0_2,0.6147972577030001,Car,0,2,commuting,2km ≥ cycling
+all age groups,females,Scenario,commuting_0_2,0.0058605157707603975,Other,0,2,commuting,2km ≥ cycling
+all age groups,females,Scenario,commuting_0_2,0.08243106095926937,Public transport,0,2,commuting,2km ≥ cycling
+all age groups,females,Scenario,commuting_0_2,0.2773496535211976,Walking,0,2,commuting,2km ≥ cycling
+all age groups,females,Scenario,all_0_5,0.30001569832043645,Cycling,0,5,all,5km ≥ cycling
+all age groups,females,Scenario,all_0_5,0.33434307142833614,Car,0,5,all,5km ≥ cycling
+all age groups,females,Scenario,all_0_5,0.0058605157707603975,Other,0,5,all,5km ≥ cycling
+all age groups,females,Scenario,all_0_5,0.08243106095926937,Public transport,0,5,all,5km ≥ cycling
+all age groups,females,Scenario,all_0_5,0.2773496535211976,Walking,0,5,all,5km ≥ cycling
+all age groups,females,Scenario,commuting_0_5,0.04372690230442163,Cycling,0,5,commuting,5km ≥ cycling
+all age groups,females,Scenario,commuting_0_5,0.5906318674443509,Car,0,5,commuting,5km ≥ cycling
+all age groups,females,Scenario,commuting_0_5,0.0058605157707603975,Other,0,5,commuting,5km ≥ cycling
+all age groups,females,Scenario,commuting_0_5,0.08243106095926937,Public transport,0,5,commuting,5km ≥ cycling
+all age groups,females,Scenario,commuting_0_5,0.2773496535211976,Walking,0,5,commuting,5km ≥ cycling
+all age groups,females,Scenario,all_1_0,0.008105780410790651,Cycling,1,0,all,1km ≥ walking
+all age groups,females,Scenario,all_1_0,0.5949220503054183,Car,1,0,all,1km ≥ walking
+all age groups,females,Scenario,all_1_0,0.0058605157707603975,Other,1,0,all,1km ≥ walking
+all age groups,females,Scenario,all_1_0,0.08243106095926937,Public transport,1,0,all,1km ≥ walking
+all age groups,females,Scenario,all_1_0,0.3086805925537612,Walking,1,0,all,1km ≥ walking
+all age groups,females,Scenario,commuting_1_0,0.008105780410790651,Cycling,1,0,commuting,1km ≥ walking
+all age groups,females,Scenario,commuting_1_0,0.6233463340285217,Car,1,0,commuting,1km ≥ walking
+all age groups,females,Scenario,commuting_1_0,0.0058605157707603975,Other,1,0,commuting,1km ≥ walking
+all age groups,females,Scenario,commuting_1_0,0.08243106095926937,Public transport,1,0,commuting,1km ≥ walking
+all age groups,females,Scenario,commuting_1_0,0.2802563088306579,Walking,1,0,commuting,1km ≥ walking
+all age groups,females,Scenario,all_1_2,0.09142779957294746,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Scenario,all_1_2,0.5116000311432616,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Scenario,all_1_2,0.0058605157707603975,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Scenario,all_1_2,0.08243106095926937,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Scenario,all_1_2,0.3086805925537612,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Scenario,commuting_1_2,0.01665485673631217,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Scenario,commuting_1_2,0.6147972577030001,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Scenario,commuting_1_2,0.0058605157707603975,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Scenario,commuting_1_2,0.08243106095926937,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Scenario,commuting_1_2,0.2802563088306579,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females,Scenario,all_1_5,0.2686847592878729,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Scenario,all_1_5,0.33434307142833614,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Scenario,all_1_5,0.0058605157707603975,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Scenario,all_1_5,0.08243106095926937,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Scenario,all_1_5,0.3086805925537612,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Scenario,commuting_1_5,0.04082024699496134,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Scenario,commuting_1_5,0.5906318674443509,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Scenario,commuting_1_5,0.0058605157707603975,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Scenario,commuting_1_5,0.08243106095926937,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Scenario,commuting_1_5,0.2802563088306579,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females,Scenario,all_2_0,0.008105780410790651,Cycling,2,0,all,2km ≥ walking
+all age groups,females,Scenario,all_2_0,0.5116000311432616,Car,2,0,all,2km ≥ walking
+all age groups,females,Scenario,all_2_0,0.0058605157707603975,Other,2,0,all,2km ≥ walking
+all age groups,females,Scenario,all_2_0,0.08243106095926937,Public transport,2,0,all,2km ≥ walking
+all age groups,females,Scenario,all_2_0,0.392002611715918,Walking,2,0,all,2km ≥ walking
+all age groups,females,Scenario,commuting_2_0,0.008105780410790651,Cycling,2,0,commuting,2km ≥ walking
+all age groups,females,Scenario,commuting_2_0,0.6147972577030001,Car,2,0,commuting,2km ≥ walking
+all age groups,females,Scenario,commuting_2_0,0.0058605157707603975,Other,2,0,commuting,2km ≥ walking
+all age groups,females,Scenario,commuting_2_0,0.08243106095926937,Public transport,2,0,commuting,2km ≥ walking
+all age groups,females,Scenario,commuting_2_0,0.28880538515617943,Walking,2,0,commuting,2km ≥ walking
+all age groups,females,Scenario,all_2_5,0.18536274012571607,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Scenario,all_2_5,0.33434307142833614,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Scenario,all_2_5,0.0058605157707603975,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Scenario,all_2_5,0.08243106095926937,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Scenario,all_2_5,0.392002611715918,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Scenario,commuting_2_5,0.032271170669439825,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Scenario,commuting_2_5,0.5906318674443509,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Scenario,commuting_2_5,0.0058605157707603975,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Scenario,commuting_2_5,0.08243106095926937,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females,Scenario,commuting_2_5,0.28880538515617943,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Base case,all_0_2,0.01297824270669996,Cycling,0,2,all,2km ≥ cycling
+all age groups,females and males,Base case,all_0_2,0.628702005615673,Car,0,2,all,2km ≥ cycling
+all age groups,females and males,Base case,all_0_2,0.007195345812681046,Other,0,2,all,2km ≥ cycling
+all age groups,females and males,Base case,all_0_2,0.08399827586953193,Public transport,0,2,all,2km ≥ cycling
+all age groups,females and males,Base case,all_0_2,0.26712612999541396,Walking,0,2,all,2km ≥ cycling
+all age groups,females and males,Base case,commuting_0_2,0.01297824270669996,Cycling,0,2,commuting,2km ≥ cycling
+all age groups,females and males,Base case,commuting_0_2,0.628702005615673,Car,0,2,commuting,2km ≥ cycling
+all age groups,females and males,Base case,commuting_0_2,0.007195345812681046,Other,0,2,commuting,2km ≥ cycling
+all age groups,females and males,Base case,commuting_0_2,0.08399827586953193,Public transport,0,2,commuting,2km ≥ cycling
+all age groups,females and males,Base case,commuting_0_2,0.26712612999541396,Walking,0,2,commuting,2km ≥ cycling
+all age groups,females and males,Base case,all_0_5,0.01297824270669996,Cycling,0,5,all,5km ≥ cycling
+all age groups,females and males,Base case,all_0_5,0.628702005615673,Car,0,5,all,5km ≥ cycling
+all age groups,females and males,Base case,all_0_5,0.007195345812681046,Other,0,5,all,5km ≥ cycling
+all age groups,females and males,Base case,all_0_5,0.08399827586953193,Public transport,0,5,all,5km ≥ cycling
+all age groups,females and males,Base case,all_0_5,0.26712612999541396,Walking,0,5,all,5km ≥ cycling
+all age groups,females and males,Base case,commuting_0_5,0.01297824270669996,Cycling,0,5,commuting,5km ≥ cycling
+all age groups,females and males,Base case,commuting_0_5,0.628702005615673,Car,0,5,commuting,5km ≥ cycling
+all age groups,females and males,Base case,commuting_0_5,0.007195345812681046,Other,0,5,commuting,5km ≥ cycling
+all age groups,females and males,Base case,commuting_0_5,0.08399827586953193,Public transport,0,5,commuting,5km ≥ cycling
+all age groups,females and males,Base case,commuting_0_5,0.26712612999541396,Walking,0,5,commuting,5km ≥ cycling
+all age groups,females and males,Base case,all_1_0,0.01297824270669996,Cycling,1,0,all,1km ≥ walking
+all age groups,females and males,Base case,all_1_0,0.628702005615673,Car,1,0,all,1km ≥ walking
+all age groups,females and males,Base case,all_1_0,0.007195345812681046,Other,1,0,all,1km ≥ walking
+all age groups,females and males,Base case,all_1_0,0.08399827586953193,Public transport,1,0,all,1km ≥ walking
+all age groups,females and males,Base case,all_1_0,0.26712612999541396,Walking,1,0,all,1km ≥ walking
+all age groups,females and males,Base case,commuting_1_0,0.01297824270669996,Cycling,1,0,commuting,1km ≥ walking
+all age groups,females and males,Base case,commuting_1_0,0.628702005615673,Car,1,0,commuting,1km ≥ walking
+all age groups,females and males,Base case,commuting_1_0,0.007195345812681046,Other,1,0,commuting,1km ≥ walking
+all age groups,females and males,Base case,commuting_1_0,0.08399827586953193,Public transport,1,0,commuting,1km ≥ walking
+all age groups,females and males,Base case,commuting_1_0,0.26712612999541396,Walking,1,0,commuting,1km ≥ walking
+all age groups,females and males,Base case,all_1_2,0.01297824270669996,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Base case,all_1_2,0.628702005615673,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Base case,all_1_2,0.007195345812681046,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Base case,all_1_2,0.08399827586953193,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Base case,all_1_2,0.26712612999541396,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Base case,commuting_1_2,0.01297824270669996,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Base case,commuting_1_2,0.628702005615673,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Base case,commuting_1_2,0.007195345812681046,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Base case,commuting_1_2,0.08399827586953193,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Base case,commuting_1_2,0.26712612999541396,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Base case,all_1_5,0.01297824270669996,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Base case,all_1_5,0.628702005615673,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Base case,all_1_5,0.007195345812681046,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Base case,all_1_5,0.08399827586953193,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Base case,all_1_5,0.26712612999541396,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Base case,commuting_1_5,0.01297824270669996,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Base case,commuting_1_5,0.628702005615673,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Base case,commuting_1_5,0.007195345812681046,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Base case,commuting_1_5,0.08399827586953193,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Base case,commuting_1_5,0.26712612999541396,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Base case,all_2_0,0.01297824270669996,Cycling,2,0,all,2km ≥ walking
+all age groups,females and males,Base case,all_2_0,0.628702005615673,Car,2,0,all,2km ≥ walking
+all age groups,females and males,Base case,all_2_0,0.007195345812681046,Other,2,0,all,2km ≥ walking
+all age groups,females and males,Base case,all_2_0,0.08399827586953193,Public transport,2,0,all,2km ≥ walking
+all age groups,females and males,Base case,all_2_0,0.26712612999541396,Walking,2,0,all,2km ≥ walking
+all age groups,females and males,Base case,commuting_2_0,0.01297824270669996,Cycling,2,0,commuting,2km ≥ walking
+all age groups,females and males,Base case,commuting_2_0,0.628702005615673,Car,2,0,commuting,2km ≥ walking
+all age groups,females and males,Base case,commuting_2_0,0.007195345812681046,Other,2,0,commuting,2km ≥ walking
+all age groups,females and males,Base case,commuting_2_0,0.08399827586953193,Public transport,2,0,commuting,2km ≥ walking
+all age groups,females and males,Base case,commuting_2_0,0.26712612999541396,Walking,2,0,commuting,2km ≥ walking
+all age groups,females and males,Base case,all_2_5,0.01297824270669996,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Base case,all_2_5,0.628702005615673,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Base case,all_2_5,0.007195345812681046,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Base case,all_2_5,0.08399827586953193,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Base case,all_2_5,0.26712612999541396,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Base case,commuting_2_5,0.01297824270669996,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Base case,commuting_2_5,0.628702005615673,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Base case,commuting_2_5,0.007195345812681046,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Base case,commuting_2_5,0.08399827586953193,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Base case,commuting_2_5,0.26712612999541396,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,all_0_2,0.12046577862011622,Cycling,0,2,all,2km ≥ cycling
+all age groups,females and males,Scenario,all_0_2,0.5212144697022568,Car,0,2,all,2km ≥ cycling
+all age groups,females and males,Scenario,all_0_2,0.007195345812681046,Other,0,2,all,2km ≥ cycling
+all age groups,females and males,Scenario,all_0_2,0.08399827586953193,Public transport,0,2,all,2km ≥ cycling
+all age groups,females and males,Scenario,all_0_2,0.26712612999541396,Walking,0,2,all,2km ≥ cycling
+all age groups,females and males,Scenario,commuting_0_2,0.02475713576000127,Cycling,0,2,commuting,2km ≥ cycling
+all age groups,females and males,Scenario,commuting_0_2,0.6169231125623718,Car,0,2,commuting,2km ≥ cycling
+all age groups,females and males,Scenario,commuting_0_2,0.007195345812681046,Other,0,2,commuting,2km ≥ cycling
+all age groups,females and males,Scenario,commuting_0_2,0.08399827586953193,Public transport,0,2,commuting,2km ≥ cycling
+all age groups,females and males,Scenario,commuting_0_2,0.26712612999541396,Walking,0,2,commuting,2km ≥ cycling
+all age groups,females and males,Scenario,all_0_5,0.291943546720324,Cycling,0,5,all,5km ≥ cycling
+all age groups,females and males,Scenario,all_0_5,0.349736701602049,Car,0,5,all,5km ≥ cycling
+all age groups,females and males,Scenario,all_0_5,0.007195345812681046,Other,0,5,all,5km ≥ cycling
+all age groups,females and males,Scenario,all_0_5,0.08399827586953193,Public transport,0,5,all,5km ≥ cycling
+all age groups,females and males,Scenario,all_0_5,0.26712612999541396,Walking,0,5,all,5km ≥ cycling
+all age groups,females and males,Scenario,commuting_0_5,0.04901848586193699,Cycling,0,5,commuting,5km ≥ cycling
+all age groups,females and males,Scenario,commuting_0_5,0.592661762460436,Car,0,5,commuting,5km ≥ cycling
+all age groups,females and males,Scenario,commuting_0_5,0.007195345812681046,Other,0,5,commuting,5km ≥ cycling
+all age groups,females and males,Scenario,commuting_0_5,0.08399827586953193,Public transport,0,5,commuting,5km ≥ cycling
+all age groups,females and males,Scenario,commuting_0_5,0.26712612999541396,Walking,0,5,commuting,5km ≥ cycling
+all age groups,females and males,Scenario,all_1_0,0.01297824270669996,Cycling,1,0,all,1km ≥ walking
+all age groups,females and males,Scenario,all_1_0,0.5981661516845775,Car,1,0,all,1km ≥ walking
+all age groups,females and males,Scenario,all_1_0,0.007195345812681046,Other,1,0,all,1km ≥ walking
+all age groups,females and males,Scenario,all_1_0,0.08399827586953193,Public transport,1,0,all,1km ≥ walking
+all age groups,females and males,Scenario,all_1_0,0.2976619839265095,Walking,1,0,all,1km ≥ walking
+all age groups,females and males,Scenario,commuting_1_0,0.01297824270669996,Cycling,1,0,commuting,1km ≥ walking
+all age groups,females and males,Scenario,commuting_1_0,0.6253055371258825,Car,1,0,commuting,1km ≥ walking
+all age groups,females and males,Scenario,commuting_1_0,0.007195345812681046,Other,1,0,commuting,1km ≥ walking
+all age groups,females and males,Scenario,commuting_1_0,0.08399827586953193,Public transport,1,0,commuting,1km ≥ walking
+all age groups,females and males,Scenario,commuting_1_0,0.2705225984852045,Walking,1,0,commuting,1km ≥ walking
+all age groups,females and males,Scenario,all_1_2,0.08992992468902071,Cycling,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Scenario,all_1_2,0.5212144697022568,Car,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Scenario,all_1_2,0.007195345812681046,Other,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Scenario,all_1_2,0.08399827586953193,Public transport,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Scenario,all_1_2,0.2976619839265095,Walking,1,2,all,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Scenario,commuting_1_2,0.02136066727021074,Cycling,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Scenario,commuting_1_2,0.6169231125623718,Car,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Scenario,commuting_1_2,0.007195345812681046,Other,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Scenario,commuting_1_2,0.08399827586953193,Public transport,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Scenario,commuting_1_2,0.2705225984852045,Walking,1,2,commuting,1km ≥ walking ; 1 km < cycling ≤ 2 km
+all age groups,females and males,Scenario,all_1_5,0.2614076927892285,Cycling,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,all_1_5,0.349736701602049,Car,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,all_1_5,0.007195345812681046,Other,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,all_1_5,0.08399827586953193,Public transport,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,all_1_5,0.2976619839265095,Walking,1,5,all,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,commuting_1_5,0.04562201737214645,Cycling,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,commuting_1_5,0.592661762460436,Car,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,commuting_1_5,0.007195345812681046,Other,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,commuting_1_5,0.08399827586953193,Public transport,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,commuting_1_5,0.2705225984852045,Walking,1,5,commuting,1km ≥ walking ; 1 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,all_2_0,0.01297824270669996,Cycling,2,0,all,2km ≥ walking
+all age groups,females and males,Scenario,all_2_0,0.5212144697022568,Car,2,0,all,2km ≥ walking
+all age groups,females and males,Scenario,all_2_0,0.007195345812681046,Other,2,0,all,2km ≥ walking
+all age groups,females and males,Scenario,all_2_0,0.08399827586953193,Public transport,2,0,all,2km ≥ walking
+all age groups,females and males,Scenario,all_2_0,0.3746136659088302,Walking,2,0,all,2km ≥ walking
+all age groups,females and males,Scenario,commuting_2_0,0.01297824270669996,Cycling,2,0,commuting,2km ≥ walking
+all age groups,females and males,Scenario,commuting_2_0,0.6169231125623718,Car,2,0,commuting,2km ≥ walking
+all age groups,females and males,Scenario,commuting_2_0,0.007195345812681046,Other,2,0,commuting,2km ≥ walking
+all age groups,females and males,Scenario,commuting_2_0,0.08399827586953193,Public transport,2,0,commuting,2km ≥ walking
+all age groups,females and males,Scenario,commuting_2_0,0.2789050230487153,Walking,2,0,commuting,2km ≥ walking
+all age groups,females and males,Scenario,all_2_5,0.18445601080690774,Cycling,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,all_2_5,0.349736701602049,Car,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,all_2_5,0.007195345812681046,Other,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,all_2_5,0.08399827586953193,Public transport,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,all_2_5,0.3746136659088302,Walking,2,5,all,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,commuting_2_5,0.037239592808635674,Cycling,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,commuting_2_5,0.592661762460436,Car,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,commuting_2_5,0.007195345812681046,Other,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,commuting_2_5,0.08399827586953193,Public transport,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km
+all age groups,females and males,Scenario,commuting_2_5,0.2789050230487153,Walking,2,5,commuting,2km ≥ walking ; 2 km < cycling ≤ 5 km

--- a/docs/preprocessing.R
+++ b/docs/preprocessing.R
@@ -1,0 +1,39 @@
+library(tidyverse)
+
+scenariosDF <- crossing(data.frame(max_walk=c(0,1,2)),
+                        data.frame(max_cycle=c(0,2,5)),
+                        data.frame(purpose=c("commuting", "all"))) %>%
+  filter(max_walk!=max_cycle) %>%
+  mutate(scen=paste0(purpose,"_",max_walk,"_",max_cycle)) %>%
+  mutate(title1=paste0(ifelse(max_walk>0, max_walk, max_cycle), "km \u2265 ",
+                       ifelse(max_walk>0, "walking", "cycling"), 
+                       ifelse(max_walk>0 & max_cycle>0, paste(
+                         " ;", max_walk, "km","<", "cycling \u2264", max_cycle, "km"), ""))) 
+
+finalLocation <- "../output/melbourne-outputs"
+
+output_df_agg_all <- readRDS(paste0(finalLocation,"/output_df_agg.rds")) %>% ## add titles
+  left_join(scenariosDF)
+output_diseases_change <- readRDS(paste0(finalLocation,"/output_diseases_change.rds")) %>% ## add titles
+  left_join(scenariosDF)
+output_life_years_change <- readRDS(paste0(finalLocation,"/output_life_years_change.rds")) %>% ## add titles
+  left_join(scenariosDF)
+PAall<-readRDS(paste0(finalLocation,"/PAall.rds")) %>% ## add titles
+  left_join(scenariosDF)
+PAallGuide<-readRDS(paste0(finalLocation,"/PAallGuide.rds")) %>% ## add titles
+  left_join(scenariosDF)
+output_transport_modes<-readRDS(paste0(finalLocation,"/output_transport_modes.rds")) %>% ## add titles
+  left_join(scenariosDF)
+
+output_transport_modes <- as_tibble(output_transport_modes %>%
+                                      mutate(mode=factor(mode,
+                                                         levels=c("walking","bicycle","public.transport","car","other"),
+                                                         labels=c("Walking","Cycling","Public transport","Car","Other"))) %>%
+                                      mutate(age=ifelse(age=="all", "all age groups", age),
+                                             sex=ifelse(sex=="all", "females and males", sex), 
+                                             sex=ifelse(sex=="male", "males", sex), 
+                                             sex=ifelse(sex=="female", "females", sex)) %>%
+                                      mutate(scenario=factor(scenario, levels=c("bl","sc"), labels=c("Base case", "Scenario"))))
+
+
+write_csv(output_transport_modes ,'output_transport_modes.csv')

--- a/docs/presentation_dashboard_MD.Rmd
+++ b/docs/presentation_dashboard_MD.Rmd
@@ -6,49 +6,23 @@ output:
   flexdashboard::flex_dashboard:
     orientation: column
     source_code: embed
-    stroyboard: true
+    storyboard: true
     navbar:
 runtime: shiny
 ---
 
 ```{r global, include=FALSE}
-library(flexdashboard)
-library(kableExtra)
-library(shiny)
-library(plotly)
+
 library(dplyr)
-library(DT)
 library(knitr)
 library(shinyWidgets)
-# install.packages('rsconnect')
-
-
-
-pacman::p_load(
-  rio,             # data import/export     
-  here,            # locate files
-  tidyverse,       # data management and visualization
-  flexdashboard,   # dashboard versions of R Markdown reports
-  shiny,           # interactive figures
-  plotly           # interactive figures
-)
+library(tidyverse)
+library(flexdashboard)
+library(shiny)
 
 
 # Load data ---------------------------------------------------------------
-scenariosDF <- crossing(data.frame(max_walk=c(0,1,2)),
-                        data.frame(max_cycle=c(0,2,5)),
-                        data.frame(purpose=c("commuting", "all"))) %>%
-  filter(max_walk!=max_cycle) %>%
-  mutate(scen=paste0(purpose,"_",max_walk,"_",max_cycle)) %>%
-  mutate(title1=paste0(ifelse(max_walk>0, max_walk, max_cycle), "km \u2265 ",
-                       ifelse(max_walk>0, "walking", "cycling"), ifelse(max_walk>0 & max_cycle>0, paste(" ;", max_walk, "km",
-                                                                                                        "<", "cycling \u2264", max_cycle, "km"), ""))) 
-
-# Combinations age and sex for graphs and results
-age_sex_cohorts <- crossing(data.frame(age=c("15-19", "20-39", "40-64", "65plus", "all")),
-                            data.frame(sex=c('male', 'female', 'all'))) %>%
-  dplyr::mutate(cohort=paste0(age,"_",sex))
-
+output_transport_modes <- read_csv('output_transport_modes.csv')
 
 diseaseLevels <- c("ishd","strk",
                    "brsc","carc","tbalc","utrc","mltm", "chml","stmc", "lvrc","hanc",
@@ -61,32 +35,6 @@ diseaseLabels <- c("Ischemic heart disease","Stroke",
                    "Diabetes type 2",
                    "Depression", 
                    "Alzheimers disease and other dementias")
-
-finalLocation <- "./output/melbourne-outputs"
-
-output_df_agg_all <- import(here(paste0(finalLocation,"/output_df_agg.rds"))) %>% ## add titles
-  left_join(scenariosDF)
-output_diseases_change <- import(here(paste0(finalLocation,"/output_diseases_change.rds"))) %>% ## add titles
-  left_join(scenariosDF)
-output_life_years_change <- import(here(paste0(finalLocation,"/output_life_years_change.rds"))) %>% ## add titles
-  left_join(scenariosDF)
-PAall<-import(here(paste0(finalLocation,"/PAall.rds"))) %>% ## add titles
-  left_join(scenariosDF)
-PAallGuide<-import(here(paste0(finalLocation,"/PAallGuide.rds"))) %>% ## add titles
-  left_join(scenariosDF)
-output_transport_modes<-import(here(paste0(finalLocation,"/output_transport_modes.rds"))) %>% ## add titles
-  left_join(scenariosDF)
-
-output_transport_modes <- as_tibble(output_transport_modes %>%
-    mutate(mode=factor(mode,
-                       levels=c("walking","bicycle","public.transport","car","other"),
-                       labels=c("Walking","Cycling","Public transport","Car","Other"))) %>%
-    mutate(age=ifelse(age=="all", "all age groups", age),
-           sex=ifelse(sex=="all", "females and males", sex), 
-           sex=ifelse(sex=="male", "males", sex), 
-           sex=ifelse(sex=="female", "females", sex)) %>%
-    mutate(scenario=factor(scenario, levels=c("bl","sc"), labels=c("Base case", "Scenario"))))
-
 ```
 
 ```{r data}


### PR DESCRIPTION
There were some issues getting the trips-replace dashboard to work (wouldn't load on shinyapps.io), so I had a go at simplifying the code:

- not all loaded libraries were required, and there is an apparent incompatibility of pacman with shiny, eg https://github.com/trinker/pacman/issues/82
- seperated data pre-processing from the dashboard code itself (35mb of inputs become 218kb csv --- so only the 218kb csv needs to be loaded for the dashboard itself) 

The app now seems to run (test implementation for now at https://anaestheteick.shinyapps.io/presentation_dashboard_MD/ as proof of concept.  It should be quicker to load and prototype further with the smaller input data.

Hope this helps!

Carl